### PR TITLE
chore: rename swap-live-app reference to exchange-sdk

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "swap-live-app",
+  "name": "exchange-sdk-example",
   "license": "MIT",
   "private": true,
   "scripts": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -2,7 +2,7 @@
   "name": "@ledgerhq/exchange-sdk",
   "version": "0.0.2-0",
   "license": "MIT",
-  "repository": "git@github.com:LedgerHQ/swap-live-app.git",
+  "repository": "git@github.com:LedgerHQ/exchange-sdk.git",
   "main": "./lib/index.js",
   "module": "./lib/index.mjs",
   "types": "./lib/index.d.ts",


### PR DESCRIPTION
Rename swap-live-app reference to exchange-sdk