### PR TITLE
[FEAT/LIVE-9342]: use bignumber and wallet-api-client as peer deps

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -48,7 +48,7 @@
     "tsup": "^7.2.0"
   },
   "peerDependencies": {
-    "@ledgerhq/wallet-api-client": "1.1.0",
+    "@ledgerhq/wallet-api-client": "^1.1.0",
     "bignumber.js": "^9.1.2"
   }
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -32,19 +32,23 @@
     "test": "jest"
   },
   "dependencies": {
-    "@ledgerhq/wallet-api-client": "1.1.0",
-    "axios": "^1.3.4",
-    "bignumber.js": "^9.1.2"
+    "axios": "^1.3.4"
   },
   "devDependencies": {
+    "@ledgerhq/wallet-api-client": "1.1.0",
     "@types/jest": "^29.5.2",
     "@types/node": "^12.12.21",
     "@typescript-eslint/eslint-plugin": "^5.53.0",
+    "bignumber.js": "^9.1.2",
     "eslint": "8.34.0",
     "eslint-config-prettier": "^8.6.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "29.6.0",
     "ts-jest": "^29.1.1",
     "tsup": "^7.2.0"
+  },
+  "peerDependencies": {
+    "@ledgerhq/wallet-api-client": "1.1.0",
+    "bignumber.js": "^9.1.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -81,16 +81,13 @@ importers:
 
   lib:
     dependencies:
-      '@ledgerhq/wallet-api-client':
-        specifier: 1.1.0
-        version: 1.1.0
       axios:
         specifier: ^1.3.4
         version: 1.3.4
-      bignumber.js:
-        specifier: ^9.1.2
-        version: 9.1.2
     devDependencies:
+      '@ledgerhq/wallet-api-client':
+        specifier: 1.1.0
+        version: 1.1.0
       '@types/jest':
         specifier: ^29.5.2
         version: 29.5.2
@@ -100,6 +97,9 @@ importers:
       '@typescript-eslint/eslint-plugin':
         specifier: ^5.53.0
         version: 5.53.0(@typescript-eslint/parser@5.60.0)(eslint@8.34.0)(typescript@4.8.3)
+      bignumber.js:
+        specifier: ^9.1.2
+        version: 9.1.2
       eslint:
         specifier: 8.34.0
         version: 8.34.0
@@ -974,11 +974,9 @@ packages:
       '@ledgerhq/logs': 6.10.1
       rxjs: 6.6.7
       semver: 7.5.3
-    dev: false
 
   /@ledgerhq/errors@6.14.0:
     resolution: {integrity: sha512-ZWJw2Ti6Dq1Ott/+qYqJdDWeZm16qI3VNG5rFlb0TQ3UcAyLIQZbnnzzdcVVwVeZiEp66WIpINd/pBdqsHVyOA==}
-    dev: false
 
   /@ledgerhq/hw-transport@6.28.8:
     resolution: {integrity: sha512-XxQVl4htd018u/M66r0iu5nlHi+J6QfdPsORzDF6N39jaz+tMqItb7tUlXM/isggcuS5lc7GJo7NOuJ8rvHZaQ==}
@@ -986,11 +984,9 @@ packages:
       '@ledgerhq/devices': 8.0.7
       '@ledgerhq/errors': 6.14.0
       events: 3.3.0
-    dev: false
 
   /@ledgerhq/logs@6.10.1:
     resolution: {integrity: sha512-z+ILK8Q3y+nfUl43ctCPuR4Y2bIxk/ooCQFwZxhtci1EhAtMDzMAx2W25qx8G1PPL9UUOdnUax19+F0OjXoj4w==}
-    dev: false
 
   /@ledgerhq/wallet-api-client@1.1.0:
     resolution: {integrity: sha512-iUFpGlTbpJw6wBD/kRtBpKi1V1BnC4RmbhmbMrKqKMPj6yj2GZuQNWzs1c+rEQ91/ER6uLhzG2Gge8+WjCRtDg==}
@@ -998,7 +994,6 @@ packages:
       '@ledgerhq/hw-transport': 6.28.8
       '@ledgerhq/wallet-api-core': 1.2.0
       bignumber.js: 9.1.2
-    dev: false
 
   /@ledgerhq/wallet-api-core@1.2.0:
     resolution: {integrity: sha512-eVCynK9T3P4H3hmUgMsBlf9hfxju0DtJCkE8ZofPya86SFBFEx28sw6J9XW3vjCFXzXs+M431EsZxVwfCBYAUg==}
@@ -1007,7 +1002,6 @@ packages:
       bignumber.js: 9.1.2
       uuid: 9.0.0
       zod: 3.22.2
-    dev: false
 
   /@next/env@13.4.1:
     resolution: {integrity: sha512-eD6WCBMFjLFooLM19SIhSkWBHtaFrZFfg2Cxnyl3vS3DAdFRfnx5TY2RxlkuKXdIRCC0ySbtK9JXXt8qLCqzZg==}
@@ -1697,7 +1691,6 @@ packages:
 
   /bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
-    dev: false
 
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
@@ -2527,7 +2520,6 @@ packages:
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
-    dev: false
 
   /execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -4338,7 +4330,6 @@ packages:
     engines: {npm: '>=2.0.0'}
     dependencies:
       tslib: 1.14.1
-    dev: false
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -4898,7 +4889,6 @@ packages:
   /uuid@9.0.0:
     resolution: {integrity: sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==}
     hasBin: true
-    dev: false
 
   /v8-to-istanbul@9.1.0:
     resolution: {integrity: sha512-6z3GW9x8G1gd+JIIgQQQxXuiJtCXeAjp6RaPEPLv62mH3iPHPxV6W3robxtCzNErRo6ZwTmzWhsbNvjyEBKzKA==}
@@ -5029,4 +5019,3 @@ packages:
 
   /zod@3.22.2:
     resolution: {integrity: sha512-wvWkphh5WQsJbVk1tbx1l1Ly4yg+XecD+Mq280uBGt9wa5BKSWf4Mhp6GmrkPixhMxmabYY7RbzlwVP32pbGCg==}
-    dev: false


### PR DESCRIPTION
Done as part of https://ledgerhq.atlassian.net/browse/LIVE-9342

I was running into issues where the `swap-live-app` was also importing a slightly different version of the wallet-api-client and bignumber which was causing issues with typing.

Perhaps it makes sense for these two dependencies to be peer?