### PR TITLE
fix: use type module

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -1,4 +1,5 @@
 {
+  "type": "module",
   "name": "@ledgerhq/exchange-sdk",
   "version": "0.0.0",
   "license": "MIT",


### PR DESCRIPTION
Use `type: "module"` to explicitly show package is a module rather than `commonjs`