### PR TITLE
fix: remove utxo while it is not supported

### DIFF
--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -286,6 +286,9 @@ export class ExchangeSDK {
       family = currency.family;
     }
 
+    // TODO: remove next line when wallet-api support btc utxoStrategy
+    delete customFeeConfig.utxoStrategy;
+
     switch (family) {
       case "bitcoin":
       case "ethereum":


### PR DESCRIPTION
Wallet-api is not supporting utxoStrategy as a valid parameter.
This line need to be removed when they support it.

https://ledgerhq.atlassian.net/browse/LIVE-10072