### PR TITLE
Add details on how to instanciate ExchangeSDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## About
 The goal of this SDK is to provide an easy way to interact with Ledger Live for exchange methods (example: Swap).
 
-This LiveApp is an example of how to interact with ExchangeSDK to ask user to validate a swap transaction.
+[This LiveApp](https://github.com/LedgerHQ/exchange-sdk/blob/main/example) is an example of how to interact with ExchangeSDK to ask user to validate a swap transaction.
 
 To have more details on how the swap features is working in Ledger Live, go to [Ledger's dev portal](https://developers.ledger.com/docs/swap/howto/providers-liveapp/).
 
@@ -54,26 +54,26 @@ You can update some of them (ex: `quoteId`), if your interface offers the user t
 Typically, the `quoteId` is an information coming from your system, so you can update its value if during your interaction with the user it has more mearning to do so.
 
 ### Using WalletAPI methods
-The ExchangeSDK is simple wrapper around the [WalletAPI](https://github.com/LedgerHQ/wallet-api). However, you cannot instanciate twice the WalletAPI client inside you LiveApp.
+The ExchangeSDK is a simple wrapper around the [WalletAPI](https://github.com/LedgerHQ/wallet-api). However, you cannot instantiate the WalletAPI client twice inside your LiveApp.
 
-So if you want to use some methods provided by WalletAPI in your LiveApp, you have the choice:
- * use the WalletAPI client instance provided by the ExchangeSDK
- * provide a WalletAPI client instance to the ExchangeSDK
+If you want to use a method(s) provided by WalletAPI in your Live App, you have two options:
+ * use the WalletAPI client instance provided by the ExchangeSDK or
+ * pass the WalletAPI client instance as the second parameter when invoking the ExchangeSDK()
 
-#### Using WalletAPI client instance
+#### Option 1: Having a direct dependency with `exchange-sdk` only
 Once you have your ExchangeSDK instance, you can call [WalletAPI methods](https://github.com/LedgerHQ/wallet-api/tree/main/packages/client) through its `walletAPI` property:
 ```js
 exchangeSDK.walletAPI.account.list()
 ```
 
 
-#### Providing WalletAPI client instance
+#### Option 2: Having a direct dependency with `wallet-api` & `exchange-sdk`
 If you already have a WalletAPI client instance, you can provide it when instanciating the ExchangeSDK:
 ```js
 const exchangeSDK = new ExchangeSDK(providerId, undefined, myWalletAPI);
 ```
 
-## What to look at the example app
+## The example app
 ### /example/src/pages/index.tsx
 `useEffect` is used when the LiveApp is launch.
 It catches the deeplink query params provided to populate the form inputs.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The goal of this SDK is to provide an easy way to interact with Ledger Live for 
 
 This LiveApp is an example of how to interact with ExchangeSDK to ask user to validate a swap transaction.
 
+To have more details on how the swap features is working in Ledger Live, go to [Ledger's dev portal](https://developers.ledger.com/docs/swap/howto/providers-liveapp/).
+
 ## Installation
 ```bash
 npm install @ledgerhq/exchange-sdk
@@ -32,7 +34,7 @@ import { ExchangeSDK, QueryParams } from "@ledgerhq/exchange-sdk";
 const exchangeSDK = new ExchangeSDK(providerId);
 ```
 
-When your LiveApp is called by Ledger Live through a deeplink, it will receive some informations. Check `QueryParams` type to have more details about it.
+When your LiveApp is called by Ledger Live through a deeplink, it will receive some informations. Check [QueryParams type](https://github.com/LedgerHQ/exchange-sdk/blob/main/lib/src/liveapp.ts) to have more details about it.
 
 Then you can call the swap method in order to start a new swap process.
 ```js
@@ -52,7 +54,7 @@ You can update some of them (ex: `quoteId`), if your interface offers the user t
 Typically, the `quoteId` is an information coming from your system, so you can update its value if during your interaction with the user it has more mearning to do so.
 
 ### Using WalletAPI methods
-The ExchangeSDK is simple wrapper around the WalletAPI. However, you cannot instanciate twice the WalletAPI client inside you LiveApp.
+The ExchangeSDK is simple wrapper around the [WalletAPI](https://github.com/LedgerHQ/wallet-api). However, you cannot instanciate twice the WalletAPI client inside you LiveApp.
 
 So if you want to use some methods provided by WalletAPI in your LiveApp, you have the choice:
  * use the WalletAPI client instance provided by the ExchangeSDK

--- a/README.md
+++ b/README.md
@@ -1,10 +1,18 @@
-# Swap LiveApp
+# Exchange SDK
 
-## Purpose
+## About
+The goal of this SDK is to provide an easy way to interact with Ledger Live for exchange methods (example: Swap).
+
 This LiveApp is an example of how to interact with ExchangeSDK to ask user to validate a swap transaction.
 
-### Setting
-For your LiveApp, you have to add the following permission in your `manifest.json` file:
+## Installation
+```bash
+npm install @ledgerhq/exchange-sdk
+```
+
+## Prerequisite
+### LiveApp Settings
+Your LiveApp will need to have the following permissions in your `manifest.json` file:
 ```json
   "permissions": [
     "account.list",
@@ -15,7 +23,55 @@ For your LiveApp, you have to add the following permission in your `manifest.jso
   ]
 ```
 
-## What to look at
+## Usage
+First you need an instance of the ExchangeSDK:
+```js
+import { ExchangeSDK, QueryParams } from "@ledgerhq/exchange-sdk";
+
+// The providerId has to be set with coordination with Ledger's team. It is your unique identifier when interacting with Ledger Live.
+const exchangeSDK = new ExchangeSDK(providerId);
+```
+
+When your LiveApp is called by Ledger Live through a deeplink, it will receive some informations. Check `QueryParams` type to have more details about it.
+
+Then you can call the swap method in order to start a new swap process.
+```js
+// Those are parameters that given through deeplink.
+exchangeSDK.swap({
+  quoteId,
+  fromAccountId,
+  toAccountId,
+  fromAmount,
+  feeStrategy,
+  customFeeConfig,
+  rate,
+});
+```
+
+You can update some of them (ex: `quoteId`), if your interface offers the user to change those parameters.
+Typically, the `quoteId` is an information coming from your system, so you can update its value if during your interaction with the user it has more mearning to do so.
+
+### Using WalletAPI methods
+The ExchangeSDK is simple wrapper around the WalletAPI. However, you cannot instanciate twice the WalletAPI client inside you LiveApp.
+
+So if you want to use some methods provided by WalletAPI in your LiveApp, you have the choice:
+ * use the WalletAPI client instance provided by the ExchangeSDK
+ * provide a WalletAPI client instance to the ExchangeSDK
+
+#### Using WalletAPI client instance
+Once you have your ExchangeSDK instance, you can call [WalletAPI methods](https://github.com/LedgerHQ/wallet-api/tree/main/packages/client) through its `walletAPI` property:
+```js
+exchangeSDK.walletAPI.account.list()
+```
+
+
+#### Providing WalletAPI client instance
+If you already have a WalletAPI client instance, you can provide it when instanciating the ExchangeSDK:
+```js
+const exchangeSDK = new ExchangeSDK(providerId, undefined, myWalletAPI);
+```
+
+## What to look at the example app
 ### /example/src/pages/index.tsx
 `useEffect` is used when the LiveApp is launch.
 It catches the deeplink query params provided to populate the form inputs.
@@ -23,10 +79,6 @@ Then it instanciate an ExchangeSDK with a default `providerId`.
 
 `onSwap` gets all form inputs info to send them to the ExchangeSDK.
 For testing purpose, a default `quoteId` is provided, but in Production this query param is mandatory.
-
-### /lib/src/index.ts
-This file is the only one you need to depends on.
-It exports all public interface to the ExchangeSDK.
 
 ## Why
 `lib/package.json` has 2 pre/post script on bump version. This is due to an [NPM issue](https://github.com/npm/npm/issues/9111).

--- a/lib/src/error.ts
+++ b/lib/src/error.ts
@@ -77,4 +77,3 @@ export class ConfirmStepError extends ExchangeError {
     this.name = "ConfirmStepError";
   }
 }
-

--- a/lib/src/liveapp.ts
+++ b/lib/src/liveapp.ts
@@ -1,5 +1,12 @@
 /**
  * LiveApp query params.
+ * @property QuoteId {string} - the rate identifier used by the user in your system
+ * @property FromAmount {string} - initial amount the user want to swap
+ * @property FromAccountId {string} - user's account id in Ledger Live repository
+ * @property ToAccountId {string} - user's account id in Ledger Live repository
+ * @property FeeStrategy {string}
+ * @property CustomFeeConfig {object} - fee configuration (URI encoded)
+ * @property ToNewTokenId {string}
  */
 export const QueryParams = {
   QuoteId: "quoteId",


### PR DESCRIPTION
Adding more details on how instanciate the `ExchangeSDK`.
Missing some info regarding how all the swap parameters may be retrieved.