### PR TITLE
feat: use custom exchange module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.vscode
+!.vscode/launch.json

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Exchange SDK
 
 ## About
+
 The goal of this SDK is to provide an easy way to interact with Ledger Live for exchange methods (example: Swap).
 
 [This LiveApp](https://github.com/LedgerHQ/exchange-sdk/blob/main/example) is an example of how to interact with ExchangeSDK to ask user to validate a swap transaction.
@@ -8,25 +9,31 @@ The goal of this SDK is to provide an easy way to interact with Ledger Live for 
 To have more details on how the swap features is working in Ledger Live, go to [Ledger's dev portal](https://developers.ledger.com/docs/swap/howto/providers-liveapp/).
 
 ## Installation
+
 ```bash
 npm install @ledgerhq/exchange-sdk
 ```
 
 ## Prerequisite
+
 ### LiveApp Settings
+
 Your LiveApp will need to have the following permissions in your `manifest.json` file:
+
 ```json
   "permissions": [
     "account.list",
     "account.request",
     "currency.list",
-    "exchange.start",
-    "exchange.complete"
+    "custom.exchange.start",
+    "custom.exchange.complete"
   ]
 ```
 
 ## Usage
+
 First you need an instance of the ExchangeSDK:
+
 ```js
 import { ExchangeSDK, QueryParams } from "@ledgerhq/exchange-sdk";
 
@@ -37,6 +44,7 @@ const exchangeSDK = new ExchangeSDK(providerId);
 When your LiveApp is called by Ledger Live through a deeplink, it will receive some informations. Check [QueryParams type](https://github.com/LedgerHQ/exchange-sdk/blob/main/lib/src/liveapp.ts) to have more details about it.
 
 Then you can call the swap method in order to start a new swap process.
+
 ```js
 // Those are parameters that given through deeplink.
 exchangeSDK.swap({
@@ -54,27 +62,34 @@ You can update some of them (ex: `quoteId`), if your interface offers the user t
 Typically, the `quoteId` is an information coming from your system, so you can update its value if during your interaction with the user it has more mearning to do so.
 
 ### Using WalletAPI methods
+
 The ExchangeSDK is a simple wrapper around the [WalletAPI](https://github.com/LedgerHQ/wallet-api). However, you cannot instantiate the WalletAPI client twice inside your LiveApp.
 
 If you want to use a method(s) provided by WalletAPI in your Live App, you have two options:
- * use the WalletAPI client instance provided by the ExchangeSDK or
- * pass the WalletAPI client instance as the second parameter when invoking the ExchangeSDK()
+
+- use the WalletAPI client instance provided by the ExchangeSDK or
+- pass the WalletAPI client instance as the second parameter when invoking the ExchangeSDK()
 
 #### Option 1: Having a direct dependency with `exchange-sdk` only
+
 Once you have your ExchangeSDK instance, you can call [WalletAPI methods](https://github.com/LedgerHQ/wallet-api/tree/main/packages/client) through its `walletAPI` property:
+
 ```js
-exchangeSDK.walletAPI.account.list()
+exchangeSDK.walletAPI.account.list();
 ```
 
-
 #### Option 2: Having a direct dependency with `wallet-api` & `exchange-sdk`
+
 If you already have a WalletAPI client instance, you can provide it when instanciating the ExchangeSDK:
+
 ```js
 const exchangeSDK = new ExchangeSDK(providerId, undefined, myWalletAPI);
 ```
 
 ## The example app
+
 ### /example/src/pages/index.tsx
+
 `useEffect` is used when the LiveApp is launch.
 It catches the deeplink query params provided to populate the form inputs.
 Then it instanciate an ExchangeSDK with a default `providerId`.
@@ -83,4 +98,5 @@ Then it instanciate an ExchangeSDK with a default `providerId`.
 For testing purpose, a default `quoteId` is provided, but in Production this query param is mandatory.
 
 ## Why
+
 `lib/package.json` has 2 pre/post script on bump version. This is due to an [NPM issue](https://github.com/npm/npm/issues/9111).

--- a/example/manifest-dev.json
+++ b/example/manifest-dev.json
@@ -8,9 +8,7 @@
   "apiVersion": "^2.0.0",
   "manifestVersion": "1",
   "branch": "experimental",
-  "categories": [
-    "swap"
-  ],
+  "categories": ["swap"],
   "currencies": "*",
   "content": {
     "shortDescription": {
@@ -37,10 +35,8 @@
     "wallet.capabilities",
     "wallet.userId",
     "wallet.info",
-    "exchange.start",
-    "exchange.complete"
+    "custom.exchange.start",
+    "custom.exchange.complete"
   ],
-  "domains": [
-    "https://*"
-  ]
+  "domains": ["https://*"]
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@babel/core": "^7.22.20",
     "@ledgerhq/wallet-api-client": "^1.5.0",
+    "@ledgerhq/wallet-api-exchange-module": "^0.1.1-custom-exchange.0",
     "@rollup/plugin-babel": "^6.0.3",
     "@rollup/plugin-commonjs": "^25.0.4",
     "@rollup/plugin-node-resolve": "^15.2.1",

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -5,7 +5,9 @@ import {
   Transaction,
   WalletAPIClient,
   WindowMessageTransport,
+  defaultLogger,
 } from "@ledgerhq/wallet-api-client";
+import { ExchangeModule } from "@ledgerhq/wallet-api-exchange-module";
 import BigNumber from "bignumber.js";
 import {
   NonceStepError,
@@ -55,6 +57,12 @@ const ExchangeType = {
   SWAP_NG: "SWAP_NG",
 } as const;
 
+function getCustomModule(client: WalletAPIClient) {
+  return {
+    exchange: new ExchangeModule(client),
+  };
+}
+
 /**
  * ExchangeSDK allows you to send a swap request to Ledger Device, through a Ledger Live request.
  * Under the hood it relies on {@link https://github.com/LedgerHQ/wallet-api WalletAPI}.
@@ -62,7 +70,7 @@ const ExchangeType = {
 // Note: maybe to use to disconnect the Transport: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry
 export class ExchangeSDK {
   readonly providerId: string;
-  readonly walletAPI: WalletAPIClient;
+  readonly walletAPI: WalletAPIClient<typeof getCustomModule>;
 
   private transport: WindowMessageTransport | undefined;
   private logger: Logger = new Logger();
@@ -77,7 +85,7 @@ export class ExchangeSDK {
   constructor(
     providerId: string,
     transport?: WindowMessageTransport,
-    walletAPI?: WalletAPIClient,
+    walletAPI?: WalletAPIClient<typeof getCustomModule>,
     env: Env = "PROD"
   ) {
     this.providerId = providerId;
@@ -89,7 +97,11 @@ export class ExchangeSDK {
         this.transport = transport;
       }
 
-      this.walletAPI = new WalletAPIClient(this.transport);
+      this.walletAPI = new WalletAPIClient(
+        this.transport,
+        defaultLogger,
+        getCustomModule
+      );
     } else {
       this.walletAPI = walletAPI;
     }
@@ -141,7 +153,7 @@ export class ExchangeSDK {
     }
 
     // 1 - Ask for deviceTransactionId
-    const deviceTransactionId = await this.walletAPI.exchange
+    const deviceTransactionId = await this.walletAPI.custom.exchange
       .start(ExchangeType.SWAP_NG)
       .catch((error: Error) => {
         const err = new NonceStepError(error);
@@ -175,7 +187,7 @@ export class ExchangeSDK {
       customFeeConfig,
     });
 
-    const tx = await this.walletAPI.exchange
+    const tx = await this.walletAPI.custom.exchange
       .completeSwap({
         provider: this.providerId,
         fromAccountId,
@@ -232,7 +244,6 @@ export class ExchangeSDK {
         const err = new ListAccountError(error);
         this.logger.error(err);
         throw err;
-        return [];
       });
 
     const fromAccount = allAccounts.find((value) => value.id === fromAccountId);
@@ -255,7 +266,6 @@ export class ExchangeSDK {
         const err = new ListCurrencyError(error);
         this.logger.error(err);
         throw err;
-        return [];
       });
     if (!fromCurrency) {
       const err = new UnknownAccountError(new Error("Unknown fromCurrency"));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@ledgerhq/wallet-api-client':
         specifier: ^1.5.0
         version: 1.5.0
+      '@ledgerhq/wallet-api-exchange-module':
+        specifier: ^0.1.1-custom-exchange.0
+        version: 0.1.1-custom-exchange.0
       '@rollup/plugin-babel':
         specifier: ^6.0.3
         version: 6.0.4(@babel/core@7.23.3)(rollup@3.29.4)
@@ -1101,6 +1104,13 @@ packages:
       bignumber.js: 9.1.2
       uuid: 9.0.1
       zod: 3.22.4
+
+  /@ledgerhq/wallet-api-exchange-module@0.1.1-custom-exchange.0:
+    resolution: {integrity: sha512-JcOE95Vh/JR4LMVK1CGgHLYRy84uQSn2VV4oFuUyVDck3oWLNAm35+76cmDzYriM5SfWu0r/H4Qf2QDQTSJ8UQ==}
+    dependencies:
+      '@ledgerhq/wallet-api-client': 1.5.0
+      '@ledgerhq/wallet-api-core': 1.6.0
+    dev: true
 
   /@next/env@13.4.1:
     resolution: {integrity: sha512-eD6WCBMFjLFooLM19SIhSkWBHtaFrZFfg2Cxnyl3vS3DAdFRfnx5TY2RxlkuKXdIRCC0ySbtK9JXXt8qLCqzZg==}


### PR DESCRIPTION
Adds the exchange module from LL and use it by default when creating the client
Also adds the correct type if passed by the user but it my be interesting to change the return type to `Partial` or something similar to allow passing a client containing more modules than just the exchange one
Changed the permissions in the example manifest and README