### PR TITLE
Simplify Rollup config

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -15,10 +15,7 @@
     "axios": "^1.3.4"
   },
   "devDependencies": {
-    "@babel/core": "^7.22.20",
-    "@ledgerhq/wallet-api-client": "^1.5.2",
-    "@ledgerhq/wallet-api-exchange-module": "0.3.0-nightly.0",
-    "@rollup/plugin-babel": "^6.0.3",
+    "@ledgerhq/wallet-api-client": "^1.5.0",
     "@rollup/plugin-commonjs": "^25.0.4",
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-typescript": "^11.1.3",

--- a/lib/package.json
+++ b/lib/package.json
@@ -15,7 +15,8 @@
     "axios": "^1.3.4"
   },
   "devDependencies": {
-    "@ledgerhq/wallet-api-client": "^1.5.0",
+    "@ledgerhq/wallet-api-client": "^1.5.2",
+    "@ledgerhq/wallet-api-exchange-module": "0.3.0-nightly.0",
     "@rollup/plugin-commonjs": "^25.0.4",
     "@rollup/plugin-node-resolve": "^15.2.1",
     "@rollup/plugin-typescript": "^11.1.3",
@@ -33,7 +34,8 @@
     "tsup": "^7.2.0"
   },
   "peerDependencies": {
-    "@ledgerhq/wallet-api-client": "^1.5.0",
+    "@ledgerhq/wallet-api-client": "^1.5.2",
+    "@ledgerhq/wallet-api-exchange-module": "0.3.0-nightly.0",
     "bignumber.js": "^9.1.2"
   }
 }

--- a/lib/rollup.config.ts
+++ b/lib/rollup.config.ts
@@ -1,9 +1,7 @@
 import commonjs from "@rollup/plugin-commonjs";
-import resolve from "@rollup/plugin-node-resolve";
 import typescript from "@rollup/plugin-typescript";
-import { babel } from "@rollup/plugin-babel";
-import { DEFAULT_EXTENSIONS } from "@babel/core";
 
+// eslint-disable-next-line import/no-anonymous-default-export
 export default {
   input: "src/index.ts",
   output: {
@@ -11,15 +9,9 @@ export default {
     format: "cjs",
   },
   plugins: [
-    resolve({
-      browser: true
-    }),
     commonjs(),
-    typescript(),
-    babel({
-      babelHelpers: "bundled",
-      exclude: "node_modules/**",
-      extensions: [...DEFAULT_EXTENSIONS, ".ts", "tsx"],
+    typescript({
+      exclude: "**/*.test.ts",
     }),
   ],
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,18 +85,9 @@ importers:
         specifier: ^1.3.4
         version: 1.3.4
     devDependencies:
-      '@babel/core':
-        specifier: ^7.22.20
-        version: 7.23.3
       '@ledgerhq/wallet-api-client':
-        specifier: ^1.5.2
+        specifier: ^1.5.0
         version: 1.5.2
-      '@ledgerhq/wallet-api-exchange-module':
-        specifier: 0.3.0-nightly.0
-        version: 0.3.0-nightly.0
-      '@rollup/plugin-babel':
-        specifier: ^6.0.3
-        version: 6.0.4(@babel/core@7.23.3)(rollup@3.29.4)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.4
         version: 25.0.7(rollup@3.29.4)
@@ -252,13 +243,6 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/types': 7.23.4
-    dev: true
-
-  /@babel/helper-module-imports@7.22.5:
-    resolution: {integrity: sha512-8Dl6+HD/cKifutF5qGd/8ZJi84QeAKh+CEe1sBzz8UayBBGg1dAIJrdHOcOM5b2MpzWL2yuotJTtGjETq0qjXg==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/types': 7.22.5
     dev: true
 
   /@babel/helper-module-transforms@7.23.3(@babel/core@7.23.3):
@@ -1124,13 +1108,6 @@ packages:
       zod: 3.22.4
     dev: true
 
-  /@ledgerhq/wallet-api-exchange-module@0.3.0-nightly.0:
-    resolution: {integrity: sha512-mErmFsg5RAv59FLn0trTgehU4huyELoqzTJUswNIwKDQzA6nQoS7CQY7cmaFh62DZ5SiTi7oLUrGHLQBmLUWzQ==}
-    dependencies:
-      '@ledgerhq/wallet-api-client': 1.5.2
-      '@ledgerhq/wallet-api-core': 1.6.2
-    dev: true
-
   /@next/env@13.4.1:
     resolution: {integrity: sha512-eD6WCBMFjLFooLM19SIhSkWBHtaFrZFfg2Cxnyl3vS3DAdFRfnx5TY2RxlkuKXdIRCC0ySbtK9JXXt8qLCqzZg==}
     dev: false
@@ -1260,25 +1237,6 @@ packages:
       open: 9.1.0
       picocolors: 1.0.0
       tslib: 2.5.3
-    dev: true
-
-  /@rollup/plugin-babel@6.0.4(@babel/core@7.23.3)(rollup@3.29.4):
-    resolution: {integrity: sha512-YF7Y52kFdFT/xVSuVdjkV5ZdX/3YtmX0QulG+x0taQOtJdHYzVU61aSSkAgVJ7NOv6qPkIYiJSgSWWN/DM5sGw==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      '@babel/core': ^7.0.0
-      '@types/babel__core': ^7.1.9
-      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
-    peerDependenciesMeta:
-      '@types/babel__core':
-        optional: true
-      rollup:
-        optional: true
-    dependencies:
-      '@babel/core': 7.23.3
-      '@babel/helper-module-imports': 7.22.5
-      '@rollup/pluginutils': 5.0.5(rollup@3.29.4)
-      rollup: 3.29.4
     dev: true
 
   /@rollup/plugin-commonjs@25.0.7(rollup@3.29.4):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,8 +86,11 @@ importers:
         version: 1.3.4
     devDependencies:
       '@ledgerhq/wallet-api-client':
-        specifier: ^1.5.0
+        specifier: ^1.5.2
         version: 1.5.2
+      '@ledgerhq/wallet-api-exchange-module':
+        specifier: 0.3.0-nightly.0
+        version: 0.3.0-nightly.0
       '@rollup/plugin-commonjs':
         specifier: ^25.0.4
         version: 25.0.7(rollup@3.29.4)
@@ -1106,6 +1109,13 @@ packages:
       bignumber.js: 9.1.2
       uuid: 9.0.1
       zod: 3.22.4
+    dev: true
+
+  /@ledgerhq/wallet-api-exchange-module@0.3.0-nightly.0:
+    resolution: {integrity: sha512-mErmFsg5RAv59FLn0trTgehU4huyELoqzTJUswNIwKDQzA6nQoS7CQY7cmaFh62DZ5SiTi7oLUrGHLQBmLUWzQ==}
+    dependencies:
+      '@ledgerhq/wallet-api-client': 1.5.2
+      '@ledgerhq/wallet-api-core': 1.6.2
     dev: true
 
   /@next/env@13.4.1:


### PR DESCRIPTION
The goal is to remove:
* test files descriptor in bundle version of the lib
* dependencies libraries embedded in the `index.js` file
