### PR TITLE
feat: update exchange error type

### DIFF
--- a/lib/src/error.ts
+++ b/lib/src/error.ts
@@ -1,5 +1,8 @@
 export class ExchangeError extends Error {
-  cause: object;
+  cause: {
+    swapCode: string;
+    [key: string]: string | Error | undefined;
+  };
   constructor(code = "swap000", nestedError?: Error) {
     super();
     this.name = "ExchangeError";


### PR DESCRIPTION
Currently the ExchangeError only returns object as the type for `ExchangeError`. This PR aims to make the typing for exchange error more accurate in it's return value.
