### PR TITLE
bugfix: remove custom gas limit on evm tx

### DIFF
--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -317,6 +317,7 @@ export class ExchangeSDK {
     switch (family) {
       case "bitcoin":
       case "ethereum":
+        delete customFeeConfig.gasLimit;
       case "algorand":
       case "crypto_org":
       case "ripple": // Todo check InitSwap 


### PR DESCRIPTION
Remove only for EVM, but this param should only be on EVM chain anyway 
Issue could happen with other chains (to be checked)