### PR TITLE
fix(live-11164): append the payinExtraId when swapping from stellar or ripple

### DIFF
--- a/ERROR.md
+++ b/ERROR.md
@@ -1,4 +1,5 @@
 # Error Management
+
 ## General flow
 
 ```mermaid
@@ -28,19 +29,23 @@ stateDiagram
 ```
 
 ## Error objects
-The ExchangeSDK can throw differents kind of errors:
-  * ExchangeError: generic exchange error
-  * NotEnoughFunds: if the user has not enough funds to start the swap transaction
-  * NonceStepError: if an error occurred during the *nonce* generation
-  * PayloadStepError: if an error occurred during the payload retrieve flow (communication with Ledger and the Provider backends)
-  * SignatureStepError: if an error occured during the signature flow
-  * ListAccountError: unable to retrieve account list
-  * ListCurrencyError: unable to retrieve list currency
-  * UnknownAccountError: unable to find from/to account in user account/currency list
-  * CancelStepError: cancel backend swap call is failing
-  * ConfirmStepError: confirm backend swap call is failing
 
-All those errors (except *NotEnoughFunds*) embed the root error/cause.
+The ExchangeSDK can throw differents kind of errors:
+
+- ExchangeError: generic exchange error
+- NotEnoughFunds: if the user has not enough funds to start the swap transaction
+- NonceStepError: if an error occurred during the _nonce_ generation
+- PayloadStepError: if an error occurred during the payload retrieve flow (communication with Ledger and the Provider backends)
+- SignatureStepError: if an error occured during the signature flow
+- ListAccountError: unable to retrieve account list
+- ListCurrencyError: unable to retrieve list currency
+- UnknownAccountError: unable to find from/to account in user account/currency list
+- CancelStepError: cancel backend swap call is failing
+- ConfirmStepError: confirm backend swap call is failing
+- PayinExtraIdError: transactions sometimes require an extra identifier to successfully process a transaction. This identifier is known as payinExtraId in our system. For XLM (Stellar Lumens) a `memoValue` required for transaction reference. For XRP, a destination `tag` is needed to identify the recipient in shared wallets.
+
+All those errors (except _NotEnoughFunds_) embed the root error/cause.
 
 ## Contributors
+
 For more details on the whole error flow, with details on Ledger Live, go to the [dedicated confluence page](https://ledgerhq.atlassian.net/wiki/spaces/PTX/pages/4144530320/Errors).

--- a/lib/src/api.test.ts
+++ b/lib/src/api.test.ts
@@ -40,6 +40,7 @@ describe("retrievePayload", () => {
       payinAddress: "0x31137882f060458bde9e9ac3caa27b030d8f85c2",
       signature: "",
       swapId: "swap-id2",
+      payinExtraId: "payinExtraId",
     };
     expect(result).toEqual(expectedResult);
     const expectedRequest = {
@@ -152,5 +153,6 @@ function swapApiResponse() {
     createdAt: "2023-07-05T22:12:15.378497Z",
     binaryPayload: "",
     signature: "",
+    payinExtraId: "payinExtraId",
   };
 }

--- a/lib/src/api.ts
+++ b/lib/src/api.ts
@@ -26,13 +26,14 @@ export type PayloadRequestData = {
   amount: BigNumber;
   amountInAtomicUnit: bigint;
   quoteId?: string;
-  toNewTokenId? : string;
+  toNewTokenId?: string;
 };
 export type PayloadResponse = {
   binaryPayload: string;
   signature: string;
   payinAddress: string;
   swapId: string;
+  payinExtraId?: string;
 };
 export async function retrievePayload(
   data: PayloadRequestData
@@ -85,6 +86,7 @@ type SwapBackendResponse = {
   createdAt: string; // ISO-8601
   binaryPayload: string;
   signature: string;
+  payinExtraId?: string;
 };
 
 function parseSwapBackendInfo(response: SwapBackendResponse): {
@@ -92,11 +94,13 @@ function parseSwapBackendInfo(response: SwapBackendResponse): {
   signature: string;
   payinAddress: string;
   swapId: string;
+  payinExtraId?: string;
 } {
   return {
     binaryPayload: response.binaryPayload,
     signature: response.signature,
     payinAddress: response.payinAddress,
     swapId: response.swapId,
+    payinExtraId: response.payinExtraId,
   };
 }

--- a/lib/src/error.ts
+++ b/lib/src/error.ts
@@ -80,3 +80,10 @@ export class ConfirmStepError extends ExchangeError {
     this.name = "ConfirmStepError";
   }
 }
+
+export class PayinExtraIdError extends ExchangeError {
+  constructor(nestedError?: Error) {
+    super("swap010", nestedError);
+    this.name = "PayinExtraIdError";
+  }
+}

--- a/lib/src/sdk.test.ts
+++ b/lib/src/sdk.test.ts
@@ -4,11 +4,21 @@ import { AccountModule } from "@ledgerhq/wallet-api-client/lib/modules/Account";
 import { CurrencyModule } from "@ledgerhq/wallet-api-client/lib/modules/Currency";
 import BigNumber from "bignumber.js";
 import { retrievePayload, confirmSwap } from "./api";
-import { ExchangeSDK, FeeStrategy } from "./sdk";
+import {
+  ExchangeSDK,
+  FeeStrategy,
+  defaultTransaction,
+  elrondTransaction,
+  modeSendTransaction,
+  rippleTransaction,
+  solanaTransaction,
+  stellarTransaction,
+  withoutGasLimitTransaction,
+} from "./sdk";
 import { WalletAPIClient } from "@ledgerhq/wallet-api-client/lib/WalletAPIClient";
+import { PayinExtraIdError } from "./error";
 
 jest.mock("./api");
-
 const accounts: Array<Partial<Account>> = [
   {
     id: "id-1",
@@ -18,6 +28,17 @@ const accounts: Array<Partial<Account>> = [
   {
     id: "id-2",
     currency: "currency-id-2",
+    spendableBalance: new BigNumber(100000000),
+  },
+  {
+    id: "id-stellar",
+    currency: "stellar",
+    spendableBalance: new BigNumber(100000000),
+  },
+  {
+    id: "id-ripple",
+    currency: "ripple",
+    spendableBalance: new BigNumber(100000000),
   },
 ];
 
@@ -70,6 +91,7 @@ describe("swap", () => {
       {
         id: "currency-id-1",
         decimals: 4,
+        family: "ethereum",
       },
     ];
     setMockedCurrencies(currencies);
@@ -91,5 +113,245 @@ describe("swap", () => {
     // THEN
     expect(walletApiClient.account.list).toBeCalled();
     expect(transactionId).toEqual("TransactionId");
+  });
+
+  it("throws PayinExtraIdError error when no payinExtraId provided for stellar", async () => {
+    const mockedTransport = {
+      onMessage: jest.fn(),
+      send: jest.fn(),
+    };
+    (retrievePayload as jest.Mock).mockResolvedValue({
+      binaryPayload: "",
+      signature: "",
+      payinAddress: "",
+      swapId: "swap-id",
+    });
+    (confirmSwap as jest.Mock).mockResolvedValue({});
+
+    const currencies: Array<Partial<Currency>> = [
+      {
+        id: "stellar",
+        family: "stellar",
+        decimals: 4,
+      },
+    ];
+    setMockedCurrencies(currencies);
+
+    const walletApiClient = new WalletAPIClient(mockedTransport);
+    const sdk = new ExchangeSDK("provider-id", undefined, walletApiClient);
+    const swapData = {
+      quoteId: "quoteId",
+      fromAccountId: "id-stellar",
+      toAccountId: "id-2",
+      fromAmount: new BigNumber("1.908"),
+      feeStrategy: "SLOW" as FeeStrategy,
+      rate: 1.2,
+    };
+
+    await expect(sdk.swap(swapData)).rejects.toThrow(PayinExtraIdError);
+  });
+
+  it("throws PayinExtraIdError error when no payinExtraId provided for ripple", async () => {
+    const mockedTransport = {
+      onMessage: jest.fn(),
+      send: jest.fn(),
+    };
+    (retrievePayload as jest.Mock).mockResolvedValue({
+      binaryPayload: "",
+      signature: "",
+      payinAddress: "",
+      swapId: "swap-id",
+    });
+    (confirmSwap as jest.Mock).mockResolvedValue({});
+
+    const currencies: Array<Partial<Currency>> = [
+      {
+        id: "ripple",
+        family: "ripple",
+        decimals: 4,
+      },
+    ];
+    setMockedCurrencies(currencies);
+
+    const walletApiClient = new WalletAPIClient(mockedTransport);
+    const sdk = new ExchangeSDK("provider-id", undefined, walletApiClient);
+    const swapData = {
+      quoteId: "quoteId",
+      fromAccountId: "id-ripple",
+      toAccountId: "id-2",
+      fromAmount: new BigNumber("1.908"),
+      feeStrategy: "SLOW" as FeeStrategy,
+      rate: 1.2,
+    };
+
+    await expect(sdk.swap(swapData)).rejects.toThrow(PayinExtraIdError);
+  });
+});
+
+describe("defaultTransaction function", () => {
+  it("creates a Transaction with correct properties", () => {
+    const transaction = defaultTransaction({
+      family: "algorand",
+      amount: new BigNumber("1.908"),
+      recipient: "ADDRESS",
+      customFeeConfig: { fee: new BigNumber("0.1") },
+    });
+
+    expect(transaction).toEqual({
+      family: "algorand",
+      amount: new BigNumber("1.908"),
+      recipient: "ADDRESS",
+      fee: new BigNumber("0.1"),
+    });
+  });
+
+  it("ignores unexpected properties in customFeeConfig", () => {
+    const transaction = defaultTransaction({
+      family: "cardano",
+      amount: new BigNumber("5"),
+      recipient: "ADDRESS",
+      customFeeConfig: { fee: new BigNumber("0.2") },
+    });
+
+    expect(transaction).toEqual({
+      family: "cardano",
+      amount: new BigNumber("5"),
+      recipient: "ADDRESS",
+      fee: new BigNumber("0.2"),
+    });
+  });
+});
+
+describe("modeSendTransaction function", () => {
+  it('creates a Transaction with mode: "send"', () => {
+    const transaction = modeSendTransaction({
+      family: "cardano",
+      amount: new BigNumber("5"),
+      recipient: "ADDRESS",
+      customFeeConfig: { fee: new BigNumber("0.01") },
+    });
+
+    expect(transaction).toEqual({
+      family: "cardano",
+      amount: new BigNumber("5"),
+      recipient: "ADDRESS",
+      mode: "send",
+      fee: new BigNumber("0.01"),
+    });
+  });
+});
+
+describe("stellarTransaction function", () => {
+  it("throws PayinExtraIdError if payinExtraId is missing", () => {
+    expect(() =>
+      stellarTransaction({
+        family: "stellar",
+        amount: new BigNumber("1.908"),
+        recipient: "ADDRESS",
+        customFeeConfig: {},
+      })
+    ).toThrowError(PayinExtraIdError);
+  });
+
+  it("creates a StellarTransaction with memoValue and memoType", () => {
+    const transaction = stellarTransaction({
+      family: "stellar",
+      amount: new BigNumber("1.908"),
+      recipient: "ADDRESS",
+      customFeeConfig: {},
+      payinExtraId: "MEMO",
+    });
+
+    expect(transaction).toEqual({
+      family: "stellar",
+      amount: new BigNumber("1.908"),
+      recipient: "ADDRESS",
+      memoValue: "MEMO",
+      memoType: "MEMO_TEXT",
+    });
+  });
+});
+
+describe("rippleTransaction function", () => {
+  it("throws PayinExtraIdError if payinExtraId is missing", () => {
+    expect(() =>
+      rippleTransaction({
+        family: "ripple",
+        amount: new BigNumber("10"),
+        recipient: "ADDRESS",
+        customFeeConfig: {},
+      })
+    ).toThrowError(PayinExtraIdError);
+  });
+
+  it("creates a RippleTransaction with tag", () => {
+    const transaction = rippleTransaction({
+      family: "ripple",
+      amount: new BigNumber("10"),
+      recipient: "ADDRESS",
+      customFeeConfig: {},
+      payinExtraId: "123456",
+    });
+
+    expect(transaction).toEqual({
+      family: "ripple",
+      amount: new BigNumber("10"),
+      recipient: "ADDRESS",
+      tag: 123456,
+    });
+  });
+});
+
+describe("withoutGasLimitTransaction function", () => {
+  it("removes gasLimit from customFeeConfig", () => {
+    const transaction = withoutGasLimitTransaction({
+      family: "bitcoin",
+      amount: new BigNumber("1"),
+      recipient: "ADDRESS",
+      customFeeConfig: { gasLimit: new BigNumber("21000") },
+    });
+
+    expect(transaction).toEqual({
+      family: "bitcoin",
+      amount: new BigNumber("1"),
+      recipient: "ADDRESS",
+    });
+  });
+});
+
+describe("solanaTransaction function", () => {
+  it("creates a SolanaTransaction with model object", () => {
+    const transaction = solanaTransaction({
+      family: "solana",
+      amount: new BigNumber("0.5"),
+      recipient: "ADDRESS",
+      customFeeConfig: {},
+    });
+
+    expect(transaction).toEqual({
+      family: "solana",
+      amount: new BigNumber("0.5"),
+      recipient: "ADDRESS",
+      model: { kind: "transfer", uiState: {} },
+    });
+  });
+});
+
+describe("elrondTransaction function", () => {
+  it('creates an ElrondTransaction with mode: "send"', () => {
+    const transaction = elrondTransaction({
+      family: "elrond",
+      amount: new BigNumber("10"),
+      recipient: "ADDRESS",
+      customFeeConfig: {},
+    });
+
+    expect(transaction).toEqual({
+      family: "elrond",
+      amount: new BigNumber("10"),
+      recipient: "ADDRESS",
+      mode: "send",
+      gasLimit: 0,
+    });
   });
 });


### PR DESCRIPTION
### Ticket
https://ledgerhq.atlassian.net/browse/LIVE-11164 

### Fixes
- Update the ripple and stellar `transaction` objects to include the  `payinExtraId` as `tag` or `memoValue` required by ripple / stellar 
- Add and throw the `swap010` PayinExtraIdError when `payinExtraId` is not present during the swap from those chains 

https://github.com/LedgerHQ/exchange-sdk/assets/11476482/1c3b4d64-4914-4042-a02a-cb236bcbaefb

### Refactoring 
Refactor the large `switch` statement into a more maintainable structure using the `transactionStrategy` map. It incorporates elements of both the Factory and Strategy design patterns.

**Implementation**
Each function (defaultTransaction, rippleTransaction, etc.) acts as a distinct strategy for handling transactions for a specific cryptocurrency family.  This is applied through having different functions for processing transactions, each of which can be selected and used based on the transaction type. This allows for easy expansion and modification of your application's behavior.  

The `transactionStrategy` map acts like a simple Factory. It doesn't create class instances but selects a specific function (strategy) to execute based on an input (family). When you call `createTransaction`  it uses this map to find and execute the correct transaction function based on the cryptocurrency type.
<img width="1471" alt="SCR-20240322-lbpb" src="https://github.com/LedgerHQ/exchange-sdk/assets/11476482/073761d9-6f05-4ca3-870a-5be70002be59">

### Tests
- fix the existing tests in api and sdk
- added 2 more tests to ensure the `payinExtraId` is present for ripple and stellar transactions 
- added 12 more tests to test the strategies functions 