### PR TITLE
fix(live-11468): throw new error

### DIFF
--- a/lib/src/api.test.ts
+++ b/lib/src/api.test.ts
@@ -36,9 +36,9 @@ describe("retrievePayload", () => {
 
     // THEN
     const expectedResult = {
-      binaryPayload: Buffer.from(""),
+      binaryPayload: "",
       payinAddress: "0x31137882f060458bde9e9ac3caa27b030d8f85c2",
-      signature: Buffer.from(""),
+      signature: "",
       swapId: "swap-id2",
     };
     expect(result).toEqual(expectedResult);

--- a/lib/src/sdk.test.ts
+++ b/lib/src/sdk.test.ts
@@ -1,49 +1,59 @@
-import {
-  Account,
-  Currency,
-  WalletAPIClient,
-} from "@ledgerhq/wallet-api-client";
+import { Account, Currency } from "@ledgerhq/wallet-api-client";
 import { ExchangeModule } from "@ledgerhq/wallet-api-client/lib/modules/Exchange";
 import { AccountModule } from "@ledgerhq/wallet-api-client/lib/modules/Account";
 import { CurrencyModule } from "@ledgerhq/wallet-api-client/lib/modules/Currency";
 import BigNumber from "bignumber.js";
 import { retrievePayload, confirmSwap } from "./api";
 import { ExchangeSDK, FeeStrategy } from "./sdk";
+import { WalletAPIClient } from "@ledgerhq/wallet-api-client/lib/WalletAPIClient";
 
 jest.mock("./api");
 
+const accounts: Array<Partial<Account>> = [
+  {
+    id: "id-1",
+    currency: "currency-id-1",
+    spendableBalance: new BigNumber(100000000),
+  },
+  {
+    id: "id-2",
+    currency: "currency-id-2",
+  },
+];
+
+const mockedCurrencies: any[] = [];
+
+function setMockedCurrencies(newCurrencies: any[]) {
+  mockedCurrencies.length = 0; // Clear existing currencies
+  mockedCurrencies.push(...newCurrencies);
+}
+
+jest.mock("@ledgerhq/wallet-api-client/lib/WalletAPIClient", () => {
+  // Mock the WalletAPIClient as a named export
+  const startSwap = jest.fn().mockResolvedValue("DeviceTransactionId");
+  const completeSwap = jest.fn().mockResolvedValue("TransactionId");
+
+  return {
+    WalletAPIClient: jest.fn().mockImplementation(() => ({
+      custom: {
+        exchange: {
+          startSwap,
+          completeSwap,
+        },
+      },
+      account: {
+        list: jest.fn().mockResolvedValue(accounts as Array<Account>),
+      },
+      currency: {
+        // can be updated in each test using the setMockedCurrencies
+        list: jest.fn(() => Promise.resolve(mockedCurrencies)),
+      },
+    })),
+  };
+});
+
 describe("swap", () => {
   it("sends back the 'transactionId' from the WalletAPI", async () => {
-    // GIVEN
-    const accounts: Array<Partial<Account>> = [
-      {
-        id: "id-1",
-        currency: "currency-id-1",
-        spendableBalance: new BigNumber(100000000),
-      },
-      {
-        id: "id-2",
-        currency: "currency-id-2",
-      },
-    ];
-    const currencies: Array<Partial<Currency>> = [
-      {
-        id: "currency-id-1",
-        decimals: 4,
-      },
-    ];
-    const mockAccountList = jest
-      .spyOn(AccountModule.prototype, "list")
-      .mockResolvedValue(accounts as Array<Account>);
-    jest
-      .spyOn(CurrencyModule.prototype, "list")
-      .mockResolvedValue(currencies as any);
-    jest
-      .spyOn(ExchangeModule.prototype, "start")
-      .mockResolvedValue("DeviceTransactionId");
-    jest
-      .spyOn(ExchangeModule.prototype, "completeSwap")
-      .mockResolvedValue("TransactionId");
     const mockedTransport = {
       onMessage: jest.fn(),
       send: jest.fn(),
@@ -55,6 +65,14 @@ describe("swap", () => {
       swapId: "swap-id",
     });
     (confirmSwap as jest.Mock).mockResolvedValue({});
+
+    const currencies: Array<Partial<Currency>> = [
+      {
+        id: "currency-id-1",
+        decimals: 4,
+      },
+    ];
+    setMockedCurrencies(currencies);
 
     const walletApiClient = new WalletAPIClient(mockedTransport);
     const sdk = new ExchangeSDK("provider-id", undefined, walletApiClient);
@@ -71,7 +89,7 @@ describe("swap", () => {
     const transactionId = await sdk.swap(swapData);
 
     // THEN
-    expect(mockAccountList).toBeCalled();
+    expect(walletApiClient.account.list).toBeCalled();
     expect(transactionId).toEqual("TransactionId");
   });
 });

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -156,12 +156,12 @@ export class ExchangeSDK {
 
     // 1 - Ask for deviceTransactionId
     const deviceTransactionId = await this.walletAPI.custom.exchange
-      .startSwap({ 
-        exchangeType: ExchangeType.SWAP, 
-        provider: this.providerId, 
-        fromAccountId, 
-        toAccountId, 
-        tokenCurrency: toNewTokenId || ''
+      .startSwap({
+        exchangeType: ExchangeType.SWAP,
+        provider: this.providerId,
+        fromAccountId,
+        toAccountId,
+        tokenCurrency: toNewTokenId || "",
       })
       .catch((error: Error) => {
         const err = new NonceStepError(error);
@@ -216,6 +216,13 @@ export class ExchangeSDK {
             throw err;
           }
         );
+
+        // defined in https://github.com/LedgerHQ/ledger-live/blob/develop/libs/ledgerjs/packages/errors/src/index.ts
+        // used for development
+        if (error.name === "DisabledTransactionBroadcastError") {
+          throw error;
+        }
+
         const err = new SignatureStepError(error);
         this.logger.error(err);
         throw err;
@@ -320,7 +327,7 @@ export class ExchangeSDK {
         delete customFeeConfig.gasLimit;
       case "algorand":
       case "crypto_org":
-      case "ripple": // Todo check InitSwap 
+      case "ripple": // Todo check InitSwap
       case "cosmos":
       case "celo":
       case "hedera":
@@ -351,13 +358,14 @@ export class ExchangeSDK {
           ...customFeeConfig,
           mode: "send",
         };
-      case "tezos": return {
-        family,
-        amount,
-        recipient,
-        ...customFeeConfig,
-        mode: "send", 
-      };
+      case "tezos":
+        return {
+          family,
+          amount,
+          recipient,
+          ...customFeeConfig,
+          mode: "send",
+        };
       case "elrond":
         return {
           family,


### PR DESCRIPTION
📝 Description
Implement DisabledTransactionBroadcastError to handle a specific development scenario where transaction broadcasts are disabled.
This error is designed exclusively for development environments, facilitating the invocation of the canceled API in the exchangeSDK without triggering any UI error notifications in Ledger Live (LL).
When the DISABLE_TRANSACTION_BROADCAST flag is set to true, the onBroadcastSuccess method triggers the onCancel function with DisabledTransactionBroadcastError.
This integration ensures that the exchange-sdk's catch logic activates, calling the canceled API. Subsequently, though the error is thrown, it is strategically caught within the swap-live-app.
Consequently, the UI remains unaffected by this error; no error state or notification disrupts the user interface in LL.
 
❓ Context
https://ledgerhq.atlassian.net/browse/LIVE-11468