### PR TITLE
fix: add message attribute to errors

### DIFF
--- a/lib/src/error.ts
+++ b/lib/src/error.ts
@@ -16,7 +16,7 @@ export class ExchangeError extends Error {
         : {}),
       ...nestedError,
     };
-    this.message = nestedError.message ? nestedError.message : `${nestedError}`;
+    this.message = nestedError?.message ? nestedError.message : `${nestedError}`;
   }
 }
 

--- a/lib/src/error.ts
+++ b/lib/src/error.ts
@@ -3,6 +3,7 @@ export class ExchangeError extends Error {
     swapCode: string;
     [key: string]: string | Error | undefined;
   };
+  message: string;
   constructor(code = "swap000", nestedError?: Error) {
     super();
     this.name = "ExchangeError";
@@ -15,6 +16,7 @@ export class ExchangeError extends Error {
         : {}),
       ...nestedError,
     };
+    this.message = nestedError.message ? nestedError.message : `${nestedError}`;
   }
 }
 


### PR DESCRIPTION
Add message attribute to errors to be shown on Sentry.

Before
<img width="250" alt="image" src="https://github.com/LedgerHQ/exchange-sdk/assets/38540290/cdf5c069-c592-49bd-b9db-0019202ea565">

After
<img width="655" alt="image" src="https://github.com/LedgerHQ/exchange-sdk/assets/38540290/f490d150-9cec-412e-82f5-71b9342231dc">
