### PR TITLE
Bugfix(LIVE-12760) : dust amount error fix on confirming a sell transaction from Coinify Widget app in Ledger Live

### DIFF
--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -327,11 +327,7 @@ export class ExchangeSDK {
     // 2 - Ask for payload creation
     this.logger.log("Call getSellDestinationAccount");
     const { recipientAddress, amount, binaryPayload, signature } =
-      await getSellPayload(
-        deviceTransactionId,
-        account.address,
-        BigInt(fromAmount.toString())
-      );
+      await getSellPayload(deviceTransactionId, account.address, BigInt(0));
 
     // Check enough fund
     const fromAmountAtomic = convertToAtomicUnit(amount, currency);


### PR DESCRIPTION
### Ticket

https://ledgerhq.atlassian.net/browse/LIVE-12760

### Description

This PR fixes a bug where on trying to make a Sell Transaction from the Coinify Widget app on Ledger Live an error was thrown. The error was "Amount is lower than dust limit" and it was caused by the amount value being in bitcoin instead of satoshi. The conversion was happening in the wrong place, this has not been fixed.