### PR TITLE
fix(LIVE-12977): ignore device disconnect error in exchange sdk

### DIFF
--- a/lib/src/handleErrors.ts
+++ b/lib/src/handleErrors.ts
@@ -16,6 +16,7 @@ export function handleErrors(walletAPI: WalletAPIClient<any>, error: any) {
       "CancelStepError",
       "ConfirmStepError",
       "SwapCompleteExchangeError",
+      "DeviceDisconnectedError",
   ]);
 
   const ignoredMessages = new Set([
@@ -29,6 +30,7 @@ export function handleErrors(walletAPI: WalletAPIClient<any>, error: any) {
   // Log and throw to Ledger Live if not ignored
   if (error instanceof ExchangeError && cause) {
       walletAPI.custom.exchange.throwExchangeErrorToLedgerLive({error});
-  } 
+  }
+
   throw error;
 }


### PR DESCRIPTION
Ignore `DeviceDisconnectedError` in Exchange sdk as this should be handled by Ledger live, handling in ExchangeSDK will cause double errors. (later being more unreadable)