### PR TITLE
fix: only publish files in dist

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -5,6 +5,9 @@
   "repository": "git@github.com:LedgerHQ/exchange-sdk.git",
   "types": "./dist/types",
   "main": "./dist",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "rimraf dist && pnpm exec rollup --config rollup.config.ts --configPlugin @rollup/plugin-typescript",
     "dev": "$npm_execpath --silent build --watch",


### PR DESCRIPTION
Currently it looks like src files are being included on npm, this should make it so only dist files are published.