### PR TITLE
fix: BigInt throws error when trying to convert number string with exponent

### DIFF
--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -405,7 +405,7 @@ function convertToAtomicUnit(amount: BigNumber, currency: Currency): bigint {
   if (!convertedNumber.isInteger()) {
     throw new Error("Unable to convert amount to atomic unit");
   }
-  return BigInt(convertedNumber.toString());
+  return BigInt(convertedNumber.toNumber());
 }
 
 function getSwapStep(error: Error): string {


### PR DESCRIPTION
Errors in sentry were noticed around the converting of an amount to its atomic unit.

This looks to only be an issue when the converted unit string has an exponent. Passing a number instead of a string seems to correctly allow the conversion of a number to a bigint while maintaining it's exponent correctly.

Example issue observed on sentry:
https://ledger.sentry.io/issues/5564248559/?environment=production&project=4505868306612224&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=24h&stream_index=1 