### PR TITLE
feat: handle close drawer error

### DIFF
--- a/lib/src/error.ts
+++ b/lib/src/error.ts
@@ -30,9 +30,11 @@ export class NonceStepError extends ExchangeError {
 }
 
 export class DrawerClosedError extends ExchangeError {
+  handled: boolean;
   constructor(nestedError?: Error) {
     super("ll001", nestedError);
     this.name = "DrawerClosedError";
+    this.handled = true;
   }
 }
 

--- a/lib/src/error.ts
+++ b/lib/src/error.ts
@@ -29,6 +29,13 @@ export class NonceStepError extends ExchangeError {
   }
 }
 
+export class DrawerClosedError extends ExchangeError {
+  constructor(nestedError?: Error) {
+    super("ll001", nestedError);
+    this.name = "DrawerClosedError";
+  }
+}
+
 export class PayloadStepError extends ExchangeError {
   constructor(nestedError?: Error) {
     super("swap002", nestedError);

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -3,6 +3,7 @@ export {
   ListAccountError,
   ListCurrencyError,
   NonceStepError,
+  DrawerClosedError,
   NotEnoughFunds,
   PayloadStepError,
   SignatureStepError,

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -214,8 +214,13 @@ export class ExchangeSDK {
           tokenCurrency: toNewTokenId || "",
         })
         .catch((error: Error) => {
-          const err = new NonceStepError(error);
-          this.logger.error(err);
+          let err;
+          if (error instanceof Error && error.name === "DrawerClosedError") {
+            err = new DrawerClosedError(error);
+          } else {
+            err = new NonceStepError(error);
+          }
+          this.logger.error(err as Error);
           throw err;
         });
     this.logger.debug("DeviceTransactionId retrieved:", deviceTransactionId);

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -22,6 +22,7 @@ import {
 } from "./api";
 import {
   CompleteExchangeError,
+  DrawerClosedError,
   IgnoredSignatureStepError,
   NonceStepError,
   NotEnoughFunds,
@@ -343,10 +344,16 @@ export class ExchangeSDK {
         provider: this.providerId,
       })
       .catch((error: Error) => {
-        const err = new NonceStepError(error);
-        this.logger.error(err);
+        let err;
+        if (error instanceof Error && error.name === "DrawerClosedError") {
+          err = new DrawerClosedError(error);
+        } else {
+          err = new NonceStepError(error);
+        }
+        this.logger.error(err as Error);
         throw err;
-      });
+      })
+
     this.logger.debug("DeviceTransactionId retrieved:", deviceTransactionId);
 
     // Step 2: Ask for payload creation


### PR DESCRIPTION
we want to throw an error from exchangeSDK when user closes the drawer on LL. In this way the partner knows the transaction was not completed and can handle the situation