### PR TITLE
chore: add product type and refactor

### DIFF
--- a/lib/src/api.test.ts
+++ b/lib/src/api.test.ts
@@ -296,24 +296,6 @@ describe("Sell", () => {
 
       expect(mockPost.mock.calls[0][0]).toEqual("card/v1/remit");
     });
-
-    it("throws error if passed in product type is not supported", async () => {
-      await expect(
-        retrieveSellPayload({
-          quoteId: "",
-          provider: "",
-          fromCurrency: "",
-          toCurrency: "",
-          refundAddress: "",
-          amountFrom: 0,
-          amountTo: 0,
-          nonce: "",
-          type: ProductType.SWAP,
-        })
-      ).rejects.toThrowError("ProductTypeNotSupported");
-
-      expect(mockPost).not.toBeCalled();
-    });
   });
 });
 
@@ -399,22 +381,6 @@ describe("Fund", () => {
 
       expect(mockPost.mock.calls[0][0]).toEqual("fund/card/v1/remit");
       expect(mockPost.mock.calls[0][1]).toEqual(expectedRequestPayload);
-    });
-
-    it("throws error if passed in product type is not supported", async () => {
-      await expect(
-        retrieveFundPayload({
-          orderId: "",
-          provider: "",
-          fromCurrency: "",
-          refundAddress: "",
-          amountFrom: 0,
-          nonce: "",
-          type: ProductType.SWAP,
-        })
-      ).rejects.toThrowError("ProductTypeNotSupported");
-
-      expect(mockPost).not.toBeCalled();
     });
   });
 });

--- a/lib/src/api.test.ts
+++ b/lib/src/api.test.ts
@@ -24,7 +24,7 @@ import {
   retrieveSwapPayload,
   SellRequestPayload,
 } from "./api";
-import { ExchangeType } from "./sdk";
+import { ProductType } from "./sdk";
 
 describe("Swap", () => {
   describe("retrieveSwapPayload", () => {
@@ -229,7 +229,7 @@ describe("Sell", () => {
         amountFrom: 0,
         amountTo: 0,
         nonce: "",
-        type: ExchangeType.SELL,
+        type: ProductType.SELL,
       };
 
       const { type, ...expectedRequestPayload } = mockRetrieveSellPayloadParams;
@@ -266,7 +266,7 @@ describe("Sell", () => {
       expect(mockPost.mock.calls[0][1]).toEqual(expectedRequestPayload);
     });
 
-    it("uses correct request url when exchange type is not SELL", async () => {
+    it("uses correct request url when product type is CARD", async () => {
       mockPost.mockResolvedValueOnce({
         data: {
           sellId: "",
@@ -291,10 +291,28 @@ describe("Sell", () => {
         amountFrom: 0,
         amountTo: 0,
         nonce: "",
-        type: ExchangeType.CARD,
+        type: ProductType.CARD,
       });
 
       expect(mockPost.mock.calls[0][0]).toEqual("card/v1/remit");
+    });
+
+    it("throws error if passed in product type is not supported", async () => {
+      await expect(
+        retrieveSellPayload({
+          quoteId: "",
+          provider: "",
+          fromCurrency: "",
+          toCurrency: "",
+          refundAddress: "",
+          amountFrom: 0,
+          amountTo: 0,
+          nonce: "",
+          type: ProductType.SWAP,
+        })
+      ).rejects.toThrowError("ProductTypeNotSupported");
+
+      expect(mockPost).not.toBeCalled();
     });
   });
 });
@@ -346,7 +364,7 @@ describe("Fund", () => {
         refundAddress: mockAccount,
         amountFrom: 0,
         nonce: "",
-        type: ExchangeType.CARD,
+        type: ProductType.CARD,
       };
 
       const { type, ...expectedRequestPayload } = mockRetrieveFundPayloadParams;
@@ -381,6 +399,22 @@ describe("Fund", () => {
 
       expect(mockPost.mock.calls[0][0]).toEqual("fund/card/v1/remit");
       expect(mockPost.mock.calls[0][1]).toEqual(expectedRequestPayload);
+    });
+
+    it("throws error if passed in product type is not supported", async () => {
+      await expect(
+        retrieveFundPayload({
+          orderId: "",
+          provider: "",
+          fromCurrency: "",
+          refundAddress: "",
+          amountFrom: 0,
+          nonce: "",
+          type: ProductType.SWAP,
+        })
+      ).rejects.toThrowError("ProductTypeNotSupported");
+
+      expect(mockPost).not.toBeCalled();
     });
   });
 });

--- a/lib/src/api.ts
+++ b/lib/src/api.ts
@@ -238,9 +238,7 @@ export async function retrieveSellPayload(data: SellRequestPayload) {
     amountTo: data.amountTo,
     nonce: data.nonce,
   };
-
   const pathname = supportedProductsByExchangeType[ExchangeType.SELL][data.type]
-
   const res = await sellAxiosClient.post(pathname!, request);
   return parseSellBackendInfo(res.data);
 }
@@ -321,9 +319,7 @@ export async function retrieveFundPayload(data: FundRequestPayload) {
     amountFrom: data.amountFrom,
     nonce: data.nonce,
   };
-
   const pathname = supportedProductsByExchangeType[ExchangeType.FUND][data.type]
-  
   const res = await fundAxiosClient.post(pathname!, request);
   return parseFundBackendInfo(res.data);
 }

--- a/lib/src/api.ts
+++ b/lib/src/api.ts
@@ -2,7 +2,7 @@ import axios from "axios";
 import { Account } from "@ledgerhq/wallet-api-client";
 import BigNumber from "bignumber.js";
 import { decodeSellPayload } from "@ledgerhq/hw-app-exchange";
-import { BEData, ExchangeType } from "./sdk";
+import { BEData, ProductType } from "./sdk";
 
 const SWAP_BACKEND_URL = "https://swap.ledger.com/v5/swap";
 const SELL_BACKEND_URL = "https://buy.api.aws.prd.ldg-tech.com/";
@@ -181,7 +181,7 @@ export interface SellRequestPayload {
   amountFrom: number;
   amountTo: number;
   nonce: string;
-  type: string;
+  type: ProductType;
 }
 
 export interface SellResponsePayload {
@@ -219,8 +219,17 @@ export async function retrieveSellPayload(data: SellRequestPayload) {
     amountTo: data.amountTo,
     nonce: data.nonce,
   };
-  const pathname = data.type === ExchangeType.SELL ? "sell/v1/remit" : "card/v1/remit";
-  const res = await sellAxiosClient.post(pathname, request);
+
+  const pathnameByProductType: Partial<{[key in ProductType]: string}> = {
+    [ProductType.CARD]: 'card/v1/remit',
+    [ProductType.SELL]: 'sell/v1/remit',
+  }
+
+  if (!pathnameByProductType[data.type]) {
+    throw new Error('ProductTypeNotSupported');
+  }
+
+  const res = await sellAxiosClient.post(pathnameByProductType[data.type]!, request);
   return parseSellBackendInfo(res.data);
 }
 
@@ -288,7 +297,7 @@ export interface FundRequestPayload {
   refundAddress: string;
   amountFrom: number;
   nonce: string;
-  type: string;
+  type: ProductType;
 }
 
 export async function retrieveFundPayload(data: FundRequestPayload) {
@@ -300,8 +309,16 @@ export async function retrieveFundPayload(data: FundRequestPayload) {
     amountFrom: data.amountFrom,
     nonce: data.nonce,
   };
-  const pathname = data.type === ExchangeType.CARD ? "fund/card/v1/remit" : ""; //TODO use this pathname if exchange type is CARD -> otherwise throw error
-  const res = await fundAxiosClient.post(pathname, request);
+
+  const pathnameByProductType: Partial<{[key in ProductType]: string}>   = {
+    [ProductType.CARD]: 'fund/card/v1/remit'
+  }
+
+  if (!pathnameByProductType[data.type]) {
+    throw new Error('ProductTypeNotSupported');
+  }
+
+  const res = await fundAxiosClient.post(pathnameByProductType[data.type]!, request);
   return parseFundBackendInfo(res.data);
 }
 
@@ -319,7 +336,6 @@ export interface FundResponsePayload {
 }
 
 const parseFundBackendInfo = (response: FundResponsePayload) => {
-  //TODO: Type this return?
   return {
     orderId: response.sellId, //TODO: Update this identifier once defined in BE
     payinAddress: response.payinAddress,

--- a/lib/src/error/ExchangeSdkError.ts
+++ b/lib/src/error/ExchangeSdkError.ts
@@ -77,7 +77,14 @@ export class PayinExtraIdError extends ExchangeBaseError {
   }
 }
 
-export type ExchangeSdkErrorType = ExchangeBaseError | NonceStepError | PayloadStepError | SignatureStepError | NotEnoughFunds | ListAccountError | ListCurrencyError | UnknownAccountError | PayinExtraIdError
+export class ProductTypeNotSupportedError extends ExchangeBaseError {
+  constructor(nestedError?: Error) {
+    super("exchange011", nestedError);
+    this.name = "ProductTypeNotSupportedError";
+  }
+}
+
+export type ExchangeSdkErrorType = ExchangeBaseError | NonceStepError | PayloadStepError | SignatureStepError | NotEnoughFunds | ListAccountError | ListCurrencyError | UnknownAccountError | PayinExtraIdError | ProductTypeNotSupportedError
 
 export default {
   ExchangeBaseError,
@@ -88,5 +95,6 @@ export default {
   ListAccountError,
   ListCurrencyError,
   UnknownAccountError,
-  PayinExtraIdError
+  PayinExtraIdError,
+  ProductTypeNotSupportedError
 }

--- a/lib/src/error/SwapError.ts
+++ b/lib/src/error/SwapError.ts
@@ -84,6 +84,13 @@ export class PayinExtraIdError extends SwapError {
   }
 }
 
+export class ProductTypeNotSupportedError extends SwapError {
+  constructor(nestedError?: Error) {
+    super("swap011", nestedError);
+    this.name = "ProductTypeNotSupportedError";
+  }
+}
+
 export type CompleteExchangeStep =
   | "INIT"
   | "SET_PARTNER_KEY"

--- a/lib/src/error/parser.test.ts
+++ b/lib/src/error/parser.test.ts
@@ -1,0 +1,39 @@
+import { ExchangeBaseError } from "./ExchangeSdkError";
+import { CustomErrorType, parseError, StepError } from "./parser";
+import { SwapError } from "./SwapError";
+
+describe("parseError", () => {
+  const mockDownstreamError = new Error("error message");
+
+  it.each(Object.values(StepError))(
+    "%s - returns generic error when customErrorType is not passed in",
+    (step) => {
+      const error = parseError({
+        error: mockDownstreamError,
+        step,
+      }) as ExchangeBaseError;
+
+      if (error?.cause?.exchangeErrorCode) {
+        expect(error.cause.exchangeErrorCode).toContain("exchange");
+      } else {
+        expect(error).toBe(mockDownstreamError);
+      }
+    }
+  );
+  it.each(Object.values(StepError))(
+    "%s - returns custom swap error when customErrorType is 'swap'",
+    (step) => {
+      const error = parseError({
+        error: mockDownstreamError,
+        step,
+        customErrorType: CustomErrorType.SWAP,
+      }) as SwapError;
+
+      if (error?.cause?.swapCode) {
+        expect(error.cause.swapCode).toContain("swap");
+      } else {
+        expect(error).toBe(mockDownstreamError);
+      }
+    }
+  );
+});

--- a/lib/src/error/parser.ts
+++ b/lib/src/error/parser.ts
@@ -1,7 +1,7 @@
 import { IgnoredSignatureStepError, ListAccountError, ListCurrencyError, NonceStepError, NotEnoughFunds, PayinExtraIdError, PayloadStepError, SignatureStepError, UnknownAccountError } from './SwapError';
 import ExchangeSdkError, { ExchangeSdkErrorType } from "./ExchangeSdkError"
 import { DrawerClosedError } from "./LedgerLiveError"
-import { FlowType } from '../sdk';
+import { ErrorType } from '../sdk';
 
 export enum StepError {
   NONCE = 'NonceStepError',
@@ -15,12 +15,12 @@ export enum StepError {
   PAYIN_EXTRA_ID = 'PayinExtraIdStepError',
 }
 
-export const parseError = (flowType: FlowType, err: Error, step?: StepError) => {
+export const parseError = (errorType: ErrorType, err: Error, step?: StepError) => {
   if (err instanceof Error && err.name === "DrawerClosedError") {
     return new DrawerClosedError(err)
   }
 
-  switch (flowType) {
+  switch (errorType) {
     case 'generic':
       const genericError = step && GenericErrors[step]
       return genericError ? new genericError(err) : err

--- a/lib/src/error/parser.ts
+++ b/lib/src/error/parser.ts
@@ -13,6 +13,7 @@ export enum StepError {
   LIST_CURRENCY = 'ListCurrencyStepError',
   UNKNOWN_ACCOUNT = 'UnknownAccountStepError',
   PAYIN_EXTRA_ID = 'PayinExtraIdStepError',
+  PRODUCT_SUPPORT = 'ProductTypeNotSupportedError',
 }
 
 export const parseError = (errorType: ErrorType, err: Error, step?: StepError) => {
@@ -39,7 +40,8 @@ const GenericErrors: Record<StepError, ErrorConstructor> = {
   [StepError.LIST_ACCOUNT]: ExchangeSdkError.ListAccountError,
   [StepError.LIST_CURRENCY]: ExchangeSdkError.ListCurrencyError,
   [StepError.UNKNOWN_ACCOUNT]: ExchangeSdkError.UnknownAccountError,
-  [StepError.PAYIN_EXTRA_ID]: ExchangeSdkError.PayinExtraIdError
+  [StepError.PAYIN_EXTRA_ID]: ExchangeSdkError.PayinExtraIdError,
+  [StepError.PRODUCT_SUPPORT]: ExchangeSdkError.ProductTypeNotSupportedError
 }
 
 const SwapErrors: Record<StepError, new (err?: Error) => Error | undefined> = {
@@ -51,5 +53,6 @@ const SwapErrors: Record<StepError, new (err?: Error) => Error | undefined> = {
   [StepError.LIST_ACCOUNT]: ListAccountError,
   [StepError.LIST_CURRENCY]: ListCurrencyError,
   [StepError.UNKNOWN_ACCOUNT]: UnknownAccountError,
-  [StepError.PAYIN_EXTRA_ID]: PayinExtraIdError
+  [StepError.PAYIN_EXTRA_ID]: PayinExtraIdError,
+  [StepError.PRODUCT_SUPPORT]: ExchangeSdkError.ProductTypeNotSupportedError
 }

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -338,6 +338,7 @@ export class ExchangeSDK {
    * @throws {ExchangeError}
    */
   async sell(info: SellInfo): Promise<string | void> {
+    this.errorType = 'generic';
     this.logger.log("*** Start Sell ***");
 
     const {
@@ -468,6 +469,7 @@ export class ExchangeSDK {
    * @throws {ExchangeError}
    */
   async fund(info: FundInfo): Promise<string | void> {
+    this.errorType = 'generic';
     this.logger.log("*** Start Fund ***");
 
     const {

--- a/lib/src/wallet-api.test.ts
+++ b/lib/src/wallet-api.test.ts
@@ -71,7 +71,7 @@ describe("stellarTransaction function", () => {
         amount: new BigNumber("1.908"),
         recipient: "ADDRESS",
         customFeeConfig: {},
-        flowType: 'swap'
+        errorType: 'swap'
       })
     ).toThrowError(PayinExtraIdError);
   });
@@ -103,7 +103,7 @@ describe("rippleTransaction function", () => {
         amount: new BigNumber("10"),
         recipient: "ADDRESS",
         customFeeConfig: {},
-        flowType: 'swap'
+        errorType: 'swap'
       })
     ).toThrowError(PayinExtraIdError);
   });

--- a/lib/src/wallet-api.test.ts
+++ b/lib/src/wallet-api.test.ts
@@ -9,6 +9,7 @@ import {
   withoutGasLimitTransaction,
 } from "./wallet-api";
 import { PayinExtraIdError } from "./error/SwapError";
+import { CustomErrorType } from "./error/parser";
 
 describe("defaultTransaction function", () => {
   it("creates a Transaction with correct properties", () => {
@@ -71,7 +72,7 @@ describe("stellarTransaction function", () => {
         amount: new BigNumber("1.908"),
         recipient: "ADDRESS",
         customFeeConfig: {},
-        errorType: 'swap'
+        customErrorType: CustomErrorType.SWAP
       })
     ).toThrowError(PayinExtraIdError);
   });
@@ -103,7 +104,7 @@ describe("rippleTransaction function", () => {
         amount: new BigNumber("10"),
         recipient: "ADDRESS",
         customFeeConfig: {},
-        errorType: 'swap'
+        customErrorType: CustomErrorType.SWAP
       })
     ).toThrowError(PayinExtraIdError);
   });


### PR DESCRIPTION
**Generic changes**
- Refactored error handling:
  - Removed references to `flowType` for clarity as the value was only used in the error handling context
  - Replaced it with an optional `customErrorType`

**Sell / Fund changes**
- Added `ProductType` to define the context in which the method is being used. E.g. `fund` with `ExchangeType.FUND` can have a `ProductType.CARD`
- Setting payload request pathname by the passed in `ProductType` and throwing a new error if the type is not supported