### PR TITLE
feat(LIVE-25390): save to wallet api storage

### DIFF
--- a/examples/live-app/manifests/manifest-dev.json
+++ b/examples/live-app/manifests/manifest-dev.json
@@ -42,5 +42,7 @@
     "custom.exchange.complete",
     "custom.close"
   ],
+  "featureFlags": ["lwmWallet40"],
+  "storage": ["exchange_sdk"],
   "domains": ["https://*", "http://*"]
 }

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -51,7 +51,7 @@ import {
 } from "./sdk.types";
 import { WalletApiDecorator } from "./wallet-api.types";
 import { ExchangeModule } from "@ledgerhq/wallet-api-exchange-module";
-import { TrackingService } from "./services/TrackingService";
+import { createTrackingDispatcher } from "./services/TrackingDispatcher";
 
 export type GetSwapPayload = typeof retrieveSwapPayload;
 
@@ -62,7 +62,7 @@ export type GetSwapPayload = typeof retrieveSwapPayload;
 export class ExchangeSDK {
   readonly providerId: string;
 
-  public tracking: TrackingService;
+  public tracking: ReturnType<typeof createTrackingDispatcher>;
 
   private walletAPIDecorator: WalletApiDecorator;
   private transport: WindowMessageTransport | Transport | undefined;
@@ -123,7 +123,7 @@ export class ExchangeSDK {
       setBackendUrl(customUrl);
     }
 
-    this.tracking = new TrackingService({
+    this.tracking = createTrackingDispatcher({
       walletAPI: this.walletAPI,
       providerId: this.providerId,
       environment,

--- a/lib/src/services/SaveToStorage.test.ts
+++ b/lib/src/services/SaveToStorage.test.ts
@@ -1,0 +1,124 @@
+import { createSaveToStorageService } from "./SaveToStorage";
+
+const STORAGE_NAMESPACE = "v4_card_integration_state";
+
+const mockWalletAPI = {
+  storage: {
+    get: jest.fn() as jest.Mock,
+    set: jest.fn() as jest.Mock,
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("createSaveToStorageService.saveToStorage", () => {
+  it("does nothing when the event type has no mapping", async () => {
+    const { saveToStorage } = createSaveToStorageService({
+      providerId: "baanx",
+      // @ts-expect-error
+      walletAPI: mockWalletAPI,
+    });
+
+    mockWalletAPI.storage.get.mockResolvedValue(null);
+
+    await saveToStorage("page_view", "unknown_page");
+
+    expect(mockWalletAPI.storage.set).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when event exists but providerId does not match", async () => {
+    const { saveToStorage } = createSaveToStorageService({
+      providerId: "not-baanx", // mismatched provider
+      // @ts-expect-error
+      walletAPI: mockWalletAPI,
+    });
+
+    mockWalletAPI.storage.get.mockResolvedValue(null);
+
+    await saveToStorage("page_view", "confirm_your_email");
+
+    expect(mockWalletAPI.storage.set).not.toHaveBeenCalled();
+  });
+
+  it("creates new storage entry when flag is updated for first time", async () => {
+    const { saveToStorage } = createSaveToStorageService({
+      providerId: "baanx",
+      // @ts-expect-error
+      walletAPI: mockWalletAPI,
+    });
+
+    mockWalletAPI.storage.get.mockResolvedValue(null);
+
+    const before = Date.now();
+    await saveToStorage("page_view", "confirm_your_email");
+    const after = Date.now();
+
+    expect(mockWalletAPI.storage.set).toHaveBeenCalledTimes(1);
+
+    const [namespace, savedValue] = mockWalletAPI.storage.set.mock.calls[0];
+    expect(namespace).toBe(STORAGE_NAMESPACE);
+
+    const parsed = JSON.parse(savedValue);
+    expect(parsed.baanx).toBeDefined();
+    expect(parsed.baanx.flags.onboarding_started).toBe(true);
+
+    // timestamp should be present and within reasonable bounds
+    const timestamp = new Date(parsed.baanx.last_updated_at).getTime();
+    expect(timestamp).toBeGreaterThanOrEqual(before);
+    expect(timestamp).toBeLessThanOrEqual(after);
+  });
+
+  it("merges with existing stored provider state", async () => {
+    const existingState = {
+      baanx: {
+        flags: {
+          onboarding_started: true,
+        },
+        last_updated_at: "2025-01-01T00:00:00.000Z",
+      },
+    };
+
+    mockWalletAPI.storage.get.mockResolvedValue(JSON.stringify(existingState));
+
+    const { saveToStorage } = createSaveToStorageService({
+      providerId: "baanx",
+      // @ts-expect-error
+      walletAPI: mockWalletAPI,
+    });
+
+    await saveToStorage("page_view", "order_your_card");
+
+    expect(mockWalletAPI.storage.set).toHaveBeenCalled();
+
+    const parsed = JSON.parse(mockWalletAPI.storage.set.mock.calls[0][1]);
+
+    // Old flag preserved
+    expect(parsed.baanx.flags.onboarding_started).toBe(true);
+
+    // New flag added
+    expect(parsed.baanx.flags.onboarding_completed).toBe(true);
+
+    // timestamp updated
+    expect(parsed.baanx.last_updated_at).not.toBe(
+      existingState.baanx.last_updated_at,
+    );
+  });
+
+  it("handles event mappings (not only page_view)", async () => {
+    mockWalletAPI.storage.get.mockResolvedValue(null);
+
+    const { saveToStorage } = createSaveToStorageService({
+      providerId: "baanx",
+      // @ts-expect-error
+      walletAPI: mockWalletAPI,
+    });
+
+    await saveToStorage("event", "topup_completed");
+
+    const saved = JSON.parse(mockWalletAPI.storage.set.mock.calls[0][1]);
+
+    expect(saved.baanx.flags.funded_card).toBe(true);
+  });
+});

--- a/lib/src/services/SaveToStorage.ts
+++ b/lib/src/services/SaveToStorage.ts
@@ -2,6 +2,7 @@ import { WalletAPIClient } from "@ledgerhq/wallet-api-client";
 import { EventMappingTable, CardProvider } from "./SaveToStorage.types";
 
 const STORAGE_NAMESPACE = "v4_card_integration_state";
+const SHARED_STORE_KEY = "exchange_sdk";
 
 const CARD_INTEGRATION_MAPPING: EventMappingTable = {
   page_view: {
@@ -47,7 +48,10 @@ export const createSaveToStorageService = ({
       return;
     }
 
-    const currentValue = await walletAPI.storage.get(STORAGE_NAMESPACE);
+    const currentValue = await walletAPI.storage.get(
+      STORAGE_NAMESPACE,
+      SHARED_STORE_KEY,
+    );
     const parsedValue = currentValue ? JSON.parse(currentValue) : {};
 
     const providerState = parsedValue[providerId] || {
@@ -59,7 +63,11 @@ export const createSaveToStorageService = ({
 
     parsedValue[providerId] = providerState;
 
-    await walletAPI.storage.set(STORAGE_NAMESPACE, JSON.stringify(parsedValue));
+    await walletAPI.storage.set(
+      STORAGE_NAMESPACE,
+      JSON.stringify(parsedValue),
+      SHARED_STORE_KEY,
+    );
   };
 
   return {

--- a/lib/src/services/SaveToStorage.ts
+++ b/lib/src/services/SaveToStorage.ts
@@ -1,0 +1,68 @@
+import { WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import { EventMappingTable, CardProvider } from "./SaveToStorage.types";
+
+const STORAGE_NAMESPACE = "v4_card_integration_state";
+
+const CARD_INTEGRATION_MAPPING: EventMappingTable = {
+  page_view: {
+    confirm_your_email: {
+      providerIds: ["baanx"],
+      flag: "onboarding_started",
+    },
+    order_your_card: {
+      providerIds: ["baanx"],
+      flag: "onboarding_completed",
+    },
+    dashboard: {
+      providerIds: ["baanx"],
+      flag: "card_active",
+    },
+  },
+
+  event: {
+    topup_completed: {
+      providerIds: ["baanx"],
+      flag: "funded_card",
+    },
+  },
+};
+
+export const createSaveToStorageService = ({
+  providerId,
+  walletAPI,
+}: {
+  providerId: string;
+  walletAPI: WalletAPIClient;
+}) => {
+  const saveToStorage = async (type: "page_view" | "event", event: string) => {
+    const typeMapping = CARD_INTEGRATION_MAPPING[type];
+
+    if (!typeMapping) {
+      return;
+    }
+
+    const mapping = typeMapping[event];
+
+    if (!mapping || !mapping.providerIds.includes(providerId as CardProvider)) {
+      return;
+    }
+
+    const currentValue = await walletAPI.storage.get(STORAGE_NAMESPACE);
+    const parsedValue = currentValue ? JSON.parse(currentValue) : {};
+
+    const providerState = parsedValue[providerId] || {
+      flags: {},
+      last_updated_at: null,
+    };
+    providerState.flags[mapping.flag] = true;
+    providerState.last_updated_at = new Date().toISOString();
+
+    parsedValue[providerId] = providerState;
+
+    await walletAPI.storage.set(STORAGE_NAMESPACE, JSON.stringify(parsedValue));
+  };
+
+  return {
+    saveToStorage,
+  };
+};

--- a/lib/src/services/SaveToStorage.types.ts
+++ b/lib/src/services/SaveToStorage.types.ts
@@ -1,0 +1,18 @@
+export type CardProvider = "baanx";
+
+type CardIntegrationFlag =
+  | "onboarding_started"
+  | "onboarding_completed"
+  | "card_active"
+  | "funded_card"
+  | "onchain_spending_used";
+
+interface EventMapping {
+  providerIds: CardProvider[];
+  flag: CardIntegrationFlag;
+}
+
+export type EventMappingTable = {
+  page_view: Record<string, EventMapping>;
+  event: Record<string, EventMapping>;
+};

--- a/lib/src/services/TrackingDispatcher.ts
+++ b/lib/src/services/TrackingDispatcher.ts
@@ -1,0 +1,48 @@
+import { WalletAPIClient } from "@ledgerhq/wallet-api-client";
+import { createSaveToStorageService } from "./SaveToStorage";
+import {
+  TrackingService,
+  TrackEvent,
+  TrackEventProperties,
+  TrackPage,
+  TrackPageProperties,
+} from "./TrackingService";
+
+export const createTrackingDispatcher = ({
+  walletAPI,
+  providerId,
+  environment,
+  providerSessionId,
+}: {
+  walletAPI: WalletAPIClient;
+  providerId: string;
+  environment?: "staging" | "preproduction" | "production";
+  providerSessionId?: string;
+}) => {
+  const tracking = new TrackingService({
+    walletAPI,
+    providerId,
+    environment,
+    providerSessionId,
+  });
+
+  const saveToStorage = createSaveToStorageService({ providerId, walletAPI });
+
+  const trackPage = async (
+    page: TrackPage,
+    props: TrackPageProperties = {},
+  ) => {
+    await tracking.trackPage(page, props);
+    saveToStorage.saveToStorage("page_view", page);
+  };
+
+  const trackEvent = async (event: TrackEvent, props: TrackEventProperties) => {
+    await tracking.trackEvent(event, props);
+    saveToStorage.saveToStorage("event", event);
+  };
+
+  return {
+    trackPage,
+    trackEvent,
+  };
+};

--- a/lib/src/services/TrackingService.ts
+++ b/lib/src/services/TrackingService.ts
@@ -7,6 +7,14 @@ import { WalletAPIClient } from "@ledgerhq/wallet-api-client";
 
 import { VERSION } from "../version";
 
+type TrackEventFn = TrackingSdk["trackEvent"];
+type TrackPageFn = TrackingSdk["trackPage"];
+
+export type TrackEvent = Parameters<TrackEventFn>[0];
+export type TrackEventProperties = Parameters<TrackEventFn>[1];
+export type TrackPage = Parameters<TrackPageFn>[0];
+export type TrackPageProperties = Parameters<TrackPageFn>[1];
+
 const CONTEXT: TrackingContext = {
   app: {
     name: "exchange-sdk",
@@ -62,8 +70,8 @@ export class TrackingService {
   }
 
   async trackEvent(
-    eventName: Parameters<TrackingSdk["trackEvent"]>[0],
-    properties: Parameters<TrackingSdk["trackEvent"]>[1],
+    eventName: TrackEvent,
+    properties: TrackEventProperties,
   ): ReturnType<TrackingSdk["trackEvent"]> {
     const optInStatus = await this.getLedgerOptInStatus();
 
@@ -79,8 +87,8 @@ export class TrackingService {
   }
 
   async trackPage(
-    pageName: Parameters<TrackingSdk["trackPage"]>[0],
-    properties: Parameters<TrackingSdk["trackPage"]>[1],
+    pageName: TrackPage,
+    properties: TrackPageProperties,
   ): ReturnType<TrackingSdk["trackPage"]> {
     const optInStatus = await this.getLedgerOptInStatus();
 


### PR DESCRIPTION
https://ledgerhq.atlassian.net/browse/LIVE-25390

When certain events or pageviews are received from a provider we want to save those to the wallet api storage so we can action certain user flows within the card app