### PR TITLE
feat: move tracking service into lib

### DIFF
--- a/lib/jest.setup.ts
+++ b/lib/jest.setup.ts
@@ -1,8 +1,9 @@
-jest.mock("@ledgerhq/tracking-sdk", () => ({
-  TrackingSdkFactory: {
-    getInstance: jest.fn(() => ({
+jest.mock("@segment/analytics-next", () => ({
+  AnalyticsBrowser: {
+    load: jest.fn(() => ({
+      track: jest.fn(),
+      page: jest.fn(),
       identify: jest.fn(),
-      trackEvent: jest.fn(),
     })),
   },
 }));

--- a/lib/package.json
+++ b/lib/package.json
@@ -19,8 +19,9 @@
   },
   "dependencies": {
     "@ledgerhq/hw-app-exchange": "^0.22.2",
-    "@ledgerhq/tracking-sdk": "^1.5.0",
-    "axios": "^1.3.4"
+    "@segment/analytics-next": "^1.81.1",
+    "axios": "^1.3.4",
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@ledgerhq/wallet-api-client": "^1.14.0",

--- a/lib/src/config/environment.ts
+++ b/lib/src/config/environment.ts
@@ -1,0 +1,21 @@
+export type Environment = "staging" | "preproduction" | "production";
+
+export interface EnvironmentConfig {
+  BUY_API_URL: string;
+  SEGMENT_WRITE_KEY: string;
+}
+
+export const environmentConfig: Record<Environment, EnvironmentConfig> = {
+  staging: {
+    BUY_API_URL: "https://buy.api.aws.stg.ldg-tech.com",
+    SEGMENT_WRITE_KEY: "1IEy9yPIYksh4yrYeKvYciLgXS9HJDbA",
+  },
+  preproduction: {
+    BUY_API_URL: "https://buy.api.live.ppr.ledger-test.com",
+    SEGMENT_WRITE_KEY: "1IEy9yPIYksh4yrYeKvYciLgXS9HJDbA",
+  },
+  production: {
+    BUY_API_URL: "https://buy.api.live.ledger.com",
+    SEGMENT_WRITE_KEY: "AEwlp5SusSLvhC6J3SmNgCnScCxnffAt",
+  },
+};

--- a/lib/src/config/events.ts
+++ b/lib/src/config/events.ts
@@ -1,9 +1,7 @@
 import { z } from "zod";
 
 export const eventSchemas = {
-  exchange_sdk_initialized: z.object({
-    providerId: z.string(),
-  }),
+  exchange_sdk_initialized: z.object({}),
   button_clicked: z.object({
     button: z.string(),
     page: z.string(),
@@ -14,7 +12,7 @@ export const eventSchemas = {
   email_confirmation_success: z.object({}),
   kyc_passed: z.object({}),
   kyc_started: z.object({}),
-  login_succesful: z.object({}),
+  login_successful: z.object({}),
   personal_information_submitted: z.object({}),
   phone_confirmation_success: z.object({}),
   physical_address_submitted: z.object({}),

--- a/lib/src/config/events.ts
+++ b/lib/src/config/events.ts
@@ -1,0 +1,44 @@
+import { z } from "zod";
+
+export const eventSchemas = {
+  exchange_sdk_initialized: z.object({
+    providerId: z.string(),
+  }),
+  button_clicked: z.object({
+    button: z.string(),
+    page: z.string(),
+    flow: z.string(),
+  }),
+
+  // AUTHENTICATION
+  email_confirmation_success: z.object({}),
+  kyc_passed: z.object({}),
+  kyc_started: z.object({}),
+  login_succesful: z.object({}),
+  personal_information_submitted: z.object({}),
+  phone_confirmation_success: z.object({}),
+  physical_address_submitted: z.object({}),
+
+  // CARD -> FUND
+  card_order_initiated: z.object({
+    cardType: z.enum(["virtual", "physical"] as const),
+  }),
+  delegation_completed: z.object({
+    limit: z.boolean(),
+    currency: z.string(),
+  }),
+  topup_completed: z.object({
+    currency_from: z.string(),
+  }),
+  topup_initiated: z.object({
+    currency_from: z.string(),
+  }),
+  withdraw: z.object({
+    currency_from: z.string(),
+    currency_to: z.string(),
+  }),
+};
+
+export type EventMap = {
+  [K in keyof typeof eventSchemas]: z.infer<(typeof eventSchemas)[K]>;
+};

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -50,6 +50,7 @@ import {
 } from "./sdk.types";
 import { WalletApiDecorator } from "./wallet-api.types";
 import { ExchangeModule } from "@ledgerhq/wallet-api-exchange-module";
+import { BackendService } from "./services/BackendService";
 import { TrackingService } from "./services/TrackingService";
 
 export type GetSwapPayload = typeof retrieveSwapPayload;
@@ -61,6 +62,7 @@ export type GetSwapPayload = typeof retrieveSwapPayload;
 export class ExchangeSDK {
   readonly providerId: string;
 
+  public backend: BackendService;
   public tracking: TrackingService;
 
   private walletAPIDecorator: WalletApiDecorator;
@@ -122,9 +124,12 @@ export class ExchangeSDK {
       setBackendUrl(customUrl);
     }
 
+    this.backend = new BackendService({ environment });
+
     this.tracking = new TrackingService({
       walletAPI: this.walletAPI,
       providerId: this.providerId,
+      backend: this.backend,
       environment,
       providerSessionId: options?.providerSessionId,
     });

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -134,9 +134,7 @@ export class ExchangeSDK {
       providerSessionId: options?.providerSessionId,
     });
 
-    this.tracking.trackEvent("exchange_sdk_initialized", {
-      providerId: this.providerId,
-    });
+    this.tracking.trackEvent("exchange_sdk_initialized", {});
   }
 
   private handleError({ error, step }: ParseError) {

--- a/lib/src/services/BackendService.test.ts
+++ b/lib/src/services/BackendService.test.ts
@@ -1,0 +1,86 @@
+import axios from "axios";
+import { BackendService } from "./BackendService";
+
+jest.mock("axios");
+
+const mockGet = jest.fn();
+const mockInterceptorUse = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (axios.create as jest.Mock).mockReturnValue({
+    get: mockGet,
+    interceptors: { request: { use: mockInterceptorUse } },
+  });
+});
+
+describe("BackendService", () => {
+  describe("constructor", () => {
+    it("creates a buy API client pointed at the production URL by default", () => {
+      new BackendService({});
+
+      expect(axios.create).toHaveBeenCalledWith({
+        baseURL: "https://buy.api.live.ledger.com",
+      });
+    });
+
+    it("creates a buy API client pointed at the staging URL", () => {
+      new BackendService({ environment: "staging" });
+
+      expect(axios.create).toHaveBeenCalledWith({
+        baseURL: "https://buy.api.aws.stg.ldg-tech.com",
+      });
+    });
+  });
+
+  describe("getLedgerSessionId", () => {
+    it("returns the session ID from the buy API", async () => {
+      mockGet.mockResolvedValue({ data: { ledgerSessionId: "sess-123" } });
+
+      const service = new BackendService({});
+      const result = await service.getLedgerSessionId();
+
+      expect(mockGet).toHaveBeenCalledWith("/session", { params: undefined });
+      expect(result).toBe("sess-123");
+    });
+
+    it("appends providerSessionId as a query param when provided", async () => {
+      mockGet.mockResolvedValue({ data: { ledgerSessionId: "sess-456" } });
+
+      const service = new BackendService({});
+      await service.getLedgerSessionId("provider-session-1");
+
+      expect(mockGet).toHaveBeenCalledWith("/session", {
+        params: { providerSessionId: "provider-session-1" },
+      });
+    });
+
+    it("returns null and logs when the response is missing ledgerSessionId", async () => {
+      mockGet.mockResolvedValue({ data: {} });
+      const consoleSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const service = new BackendService({});
+      const result = await service.getLedgerSessionId();
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it("returns null and logs on network error", async () => {
+      mockGet.mockRejectedValue(new Error("Network error"));
+      const consoleSpy = jest
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const service = new BackendService({});
+      const result = await service.getLedgerSessionId();
+
+      expect(result).toBeNull();
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/lib/src/services/BackendService.ts
+++ b/lib/src/services/BackendService.ts
@@ -1,0 +1,42 @@
+import axios, { AxiosInstance } from "axios";
+
+import { environmentConfig, type Environment } from "../config/environment";
+import { VERSION } from "../version";
+
+export class BackendService {
+  private buyApiClient: AxiosInstance;
+
+  constructor({ environment = "production" }: { environment?: Environment }) {
+    this.buyApiClient = BackendService.createClient(
+      environmentConfig[environment].BUY_API_URL,
+    );
+  }
+
+  private static createClient(baseUrl: string): AxiosInstance {
+    const client = axios.create({ baseURL: baseUrl });
+    client.interceptors.request.use((config) => {
+      config.headers = config.headers || {};
+      config.headers["x-exchange-sdk-version"] = VERSION;
+      return config;
+    });
+    return client;
+  }
+
+  async getLedgerSessionId(
+    providerSessionId?: string,
+  ): Promise<string | null> {
+    const params = providerSessionId ? { providerSessionId } : undefined;
+    try {
+      const { data } = await this.buyApiClient.get<{
+        ledgerSessionId?: string;
+      }>("/session", { params });
+      if (!data.ledgerSessionId) {
+        throw new Error("Response missing 'ledgerSessionId'");
+      }
+      return data.ledgerSessionId;
+    } catch (err) {
+      console.error("Failed to get ledgerSessionId:", err);
+      return null;
+    }
+  }
+}

--- a/lib/src/services/TrackingService.test.ts
+++ b/lib/src/services/TrackingService.test.ts
@@ -1,22 +1,36 @@
-import { TrackingSdkFactory } from "@ledgerhq/tracking-sdk";
+import { AnalyticsBrowser } from "@segment/analytics-next";
 import { TrackingService } from "./TrackingService";
 import { VERSION } from "../version";
 
+jest.mock("@segment/analytics-next", () => ({
+  AnalyticsBrowser: {
+    load: jest.fn(),
+  },
+}));
+
+const FAKE_SESSION_ID = "session-abc";
+
+function makeBackend(sessionId: string | null = FAKE_SESSION_ID) {
+  return {
+    getLedgerSessionId: jest.fn().mockResolvedValue(sessionId),
+  } as any;
+}
+
 describe("TrackingService", () => {
+  const mockTrack = jest.fn();
+  const mockPage = jest.fn();
   const mockIdentify = jest.fn();
-  const mockTrackEvent = jest.fn();
-  const fakeClient = {
-    identify: mockIdentify,
-    trackEvent: mockTrackEvent,
-  };
 
   beforeEach(() => {
     jest.clearAllMocks();
-    // TrackingSdkFactory is mocked in jest.setup.ts
-    (TrackingSdkFactory as any).getInstance.mockReturnValue(fakeClient);
+    (AnalyticsBrowser.load as jest.Mock).mockReturnValue({
+      track: mockTrack,
+      page: mockPage,
+      identify: mockIdentify,
+    });
   });
 
-  it("initializes client calls identify with userId", async () => {
+  it("calls identify with userId on init", async () => {
     const walletAPI = {
       wallet: {
         userId: jest.fn().mockResolvedValue("user-123"),
@@ -24,23 +38,19 @@ describe("TrackingService", () => {
       },
     } as any;
 
-    const trackingService = new TrackingService({
+    new TrackingService({
       walletAPI,
       providerId: "provider-xyz",
+      backend: makeBackend(),
     });
 
-    expect((TrackingSdkFactory as any).getInstance).toHaveBeenCalled();
-
-    // wait for the promise in updateUserId to resolve
     await new Promise((r) => setImmediate(r));
 
     expect(walletAPI.wallet.userId).toHaveBeenCalled();
-    expect(walletAPI.wallet.info).toHaveBeenCalled();
     expect(mockIdentify).toHaveBeenCalledWith("user-123");
-    expect(trackingService.client).toBe(fakeClient);
   });
 
-  it("initializes client with provided environment", async () => {
+  it("initializes Segment with the correct write key for environment", () => {
     const walletAPI = {
       wallet: {
         userId: jest.fn().mockResolvedValue("u"),
@@ -52,15 +62,36 @@ describe("TrackingService", () => {
       walletAPI,
       environment: "production",
       providerId: "provider-xyz",
+      backend: makeBackend(),
     });
 
-    expect((TrackingSdkFactory as any).getInstance).toHaveBeenCalledWith({
-      environment: "production",
-    });
+    expect(AnalyticsBrowser.load).toHaveBeenCalledWith(
+      { writeKey: "AEwlp5SusSLvhC6J3SmNgCnScCxnffAt" },
+      { disableClientPersistence: true },
+    );
   });
 
-  it("trackEvent forwards event, properties and context and returns client's result", async () => {
-    mockTrackEvent.mockReturnValue("ok");
+  it("requests ledger session ID from BackendService on init", () => {
+    const walletAPI = {
+      wallet: {
+        userId: jest.fn().mockResolvedValue("u"),
+        info: jest.fn().mockResolvedValue({ tracking: true }),
+      },
+    } as any;
+    const backend = makeBackend();
+
+    new TrackingService({
+      walletAPI,
+      providerId: "provider-xyz",
+      backend,
+      providerSessionId: "prov-session-1",
+    });
+
+    expect(backend.getLedgerSessionId).toHaveBeenCalledWith("prov-session-1");
+  });
+
+  it("trackEvent forwards event with enriched properties and context", async () => {
+    mockTrack.mockResolvedValue("ok");
     const walletAPI = {
       wallet: {
         userId: jest.fn().mockResolvedValue("u"),
@@ -71,15 +102,16 @@ describe("TrackingService", () => {
     const trackingService = new TrackingService({
       walletAPI,
       providerId: "provider-xyz",
-    });
-    // @ts-expect-error event name or params do not matter for this test
-    const result = await trackingService.trackEvent("my-event", {
-      a: 1,
+      backend: makeBackend(),
     });
 
-    expect(mockTrackEvent).toHaveBeenCalledWith(
-      "my-event",
-      { a: 1, providerId: "provider-xyz" },
+    const result = await trackingService.trackEvent("exchange_sdk_initialized", {
+      providerId: "provider-xyz",
+    });
+
+    expect(mockTrack).toHaveBeenCalledWith(
+      "exchange_sdk_initialized",
+      { providerId: "provider-xyz", ledgerSessionId: FAKE_SESSION_ID },
       { app: { name: "exchange-sdk", version: VERSION } },
     );
     expect(result).toBe("ok");
@@ -96,12 +128,14 @@ describe("TrackingService", () => {
     const trackingService = new TrackingService({
       walletAPI,
       providerId: "provider-xyz",
+      backend: makeBackend(),
     });
 
-    // @ts-expect-error event name or params do not matter for this test
-    const result = await trackingService.trackEvent("my-event", { a: 1 });
+    const result = await trackingService.trackEvent("exchange_sdk_initialized", {
+      providerId: "provider-xyz",
+    });
 
-    expect(mockTrackEvent).not.toHaveBeenCalled();
+    expect(mockTrack).not.toHaveBeenCalled();
     expect(result).toBeUndefined();
   });
 });

--- a/lib/src/services/TrackingService.test.ts
+++ b/lib/src/services/TrackingService.test.ts
@@ -1,12 +1,7 @@
 import { AnalyticsBrowser } from "@segment/analytics-next";
 import { TrackingService } from "./TrackingService";
 import { VERSION } from "../version";
-
-jest.mock("@segment/analytics-next", () => ({
-  AnalyticsBrowser: {
-    load: jest.fn(),
-  },
-}));
+import { environmentConfig } from "../config/environment";
 
 const FAKE_SESSION_ID = "session-abc";
 
@@ -66,7 +61,7 @@ describe("TrackingService", () => {
     });
 
     expect(AnalyticsBrowser.load).toHaveBeenCalledWith(
-      { writeKey: "AEwlp5SusSLvhC6J3SmNgCnScCxnffAt" },
+      { writeKey: environmentConfig.production.SEGMENT_WRITE_KEY },
       { disableClientPersistence: true },
     );
   });
@@ -105,9 +100,7 @@ describe("TrackingService", () => {
       backend: makeBackend(),
     });
 
-    const result = await trackingService.trackEvent("exchange_sdk_initialized", {
-      providerId: "provider-xyz",
-    });
+    const result = await trackingService.trackEvent("exchange_sdk_initialized", {});
 
     expect(mockTrack).toHaveBeenCalledWith(
       "exchange_sdk_initialized",
@@ -131,9 +124,7 @@ describe("TrackingService", () => {
       backend: makeBackend(),
     });
 
-    const result = await trackingService.trackEvent("exchange_sdk_initialized", {
-      providerId: "provider-xyz",
-    });
+    const result = await trackingService.trackEvent("exchange_sdk_initialized", {});
 
     expect(mockTrack).not.toHaveBeenCalled();
     expect(result).toBeUndefined();

--- a/lib/src/services/TrackingService.ts
+++ b/lib/src/services/TrackingService.ts
@@ -97,13 +97,13 @@ export class TrackingService {
 
     const ledgerSessionId = await this.ledgerSessionIdPromise;
     const enhancedProperties = {
-      ...properties,
+      ...result.data,
       providerId: this.providerId,
-      ledgerSessionId,
+      ...(ledgerSessionId !== null && { ledgerSessionId }),
     };
 
     try {
-      return this.segment.track(eventName, enhancedProperties, CONTEXT);
+      return await this.segment.track(eventName, enhancedProperties, CONTEXT);
     } catch (error) {
       console.error("[TrackingService] Error sending event", error);
     }
@@ -120,11 +120,11 @@ export class TrackingService {
     const enhancedProperties = {
       ...properties,
       providerId: this.providerId,
-      ledgerSessionId,
+      ...(ledgerSessionId !== null && { ledgerSessionId }),
     };
 
     try {
-      return this.segment.page(pageName, enhancedProperties, CONTEXT);
+      return await this.segment.page(pageName, enhancedProperties, CONTEXT);
     } catch (error) {
       console.error("[TrackingService] Error sending page view", error);
     }

--- a/lib/src/services/TrackingService.ts
+++ b/lib/src/services/TrackingService.ts
@@ -1,11 +1,18 @@
-import {
-  TrackingSdkFactory,
-  TrackingSdk,
-  TrackingContext,
-} from "@ledgerhq/tracking-sdk";
+import type { Context } from "@segment/analytics-next";
+import { AnalyticsBrowser } from "@segment/analytics-next";
 import { WalletAPIClient } from "@ledgerhq/wallet-api-client";
 
+import { environmentConfig, type Environment } from "../config/environment";
+import { eventSchemas, type EventMap } from "../config/events";
 import { VERSION } from "../version";
+import { BackendService } from "./BackendService";
+
+interface TrackingContext {
+  app: {
+    name: string;
+    version: string;
+  };
+}
 
 const CONTEXT: TrackingContext = {
   app: {
@@ -13,35 +20,42 @@ const CONTEXT: TrackingContext = {
     version: VERSION,
   },
 };
-export class TrackingService {
-  public client: TrackingSdk;
 
+export class TrackingService {
+  private segment: AnalyticsBrowser;
   private walletAPI: WalletAPIClient;
   private providerId: string;
   private optInStatusPromise: Promise<boolean>;
+  private ledgerSessionIdPromise: Promise<string | null>;
 
   constructor({
     walletAPI,
     providerId,
-    environment,
+    backend,
     providerSessionId,
+    environment = "production",
   }: {
     walletAPI: WalletAPIClient;
     providerId: string;
-    environment?: "staging" | "preproduction" | "production";
+    backend: BackendService;
     providerSessionId?: string;
+    environment?: Environment;
   }) {
+    const { SEGMENT_WRITE_KEY } = environmentConfig[environment];
+
     this.walletAPI = walletAPI;
     this.providerId = providerId;
-    this.client = TrackingSdkFactory.getInstance({
-      environment,
-      providerSessionId,
-    });
+    this.segment = AnalyticsBrowser.load(
+      { writeKey: SEGMENT_WRITE_KEY },
+      { disableClientPersistence: true },
+    );
+
+    this.ledgerSessionIdPromise = backend.getLedgerSessionId(providerSessionId);
     this.optInStatusPromise = this.fetchOptInStatus();
     this.updateUserId();
   }
 
-  fetchOptInStatus() {
+  fetchOptInStatus(): Promise<boolean> {
     return this.walletAPI.wallet.info().then((info) => info.tracking);
   }
 
@@ -49,49 +63,70 @@ export class TrackingService {
     return this.optInStatusPromise;
   }
 
-  async updateUserId() {
+  async updateUserId(): Promise<void> {
     const optInStatus = await this.getLedgerOptInStatus();
-
-    if (!optInStatus) {
-      return;
-    }
-
+    if (!optInStatus) return;
     this.walletAPI.wallet.userId().then((userId) => {
-      this.client.identify(userId);
+      this.segment.identify(userId);
     });
   }
 
-  async trackEvent(
-    eventName: Parameters<TrackingSdk["trackEvent"]>[0],
-    properties: Parameters<TrackingSdk["trackEvent"]>[1],
-  ): ReturnType<TrackingSdk["trackEvent"]> {
+  async trackEvent<K extends keyof EventMap>(
+    eventName: K,
+    properties: EventMap[K],
+  ): Promise<Context | void> {
     const optInStatus = await this.getLedgerOptInStatus();
+    if (!optInStatus) return;
 
-    if (!optInStatus) {
+    const schema = eventSchemas[eventName];
+    if (!schema) {
+      console.error(
+        `[TrackingService] Invalid event name "${String(eventName)}"`,
+      );
       return;
     }
 
+    const result = schema.safeParse(properties);
+    if (!result.success) {
+      console.error(
+        `[TrackingService] Invalid event params for "${String(eventName)}":`,
+        result.error.format(),
+      );
+      return;
+    }
+
+    const ledgerSessionId = await this.ledgerSessionIdPromise;
     const enhancedProperties = {
       ...properties,
       providerId: this.providerId,
+      ledgerSessionId,
     };
-    return this.client.trackEvent(eventName, enhancedProperties, CONTEXT);
+
+    try {
+      return this.segment.track(eventName, enhancedProperties, CONTEXT);
+    } catch (error) {
+      console.error("[TrackingService] Error sending event", error);
+    }
   }
 
   async trackPage(
-    pageName: Parameters<TrackingSdk["trackPage"]>[0],
-    properties: Parameters<TrackingSdk["trackPage"]>[1],
-  ): ReturnType<TrackingSdk["trackPage"]> {
+    pageName: string,
+    properties: Record<string, any>,
+  ): Promise<Context | void> {
     const optInStatus = await this.getLedgerOptInStatus();
+    if (!optInStatus) return;
 
-    if (!optInStatus) {
-      return;
-    }
-
+    const ledgerSessionId = await this.ledgerSessionIdPromise;
     const enhancedProperties = {
       ...properties,
       providerId: this.providerId,
+      ledgerSessionId,
     };
-    return this.client.trackPage(pageName, enhancedProperties, CONTEXT);
+
+    try {
+      return this.segment.page(pageName, enhancedProperties, CONTEXT);
+    } catch (error) {
+      console.error("[TrackingService] Error sending page view", error);
+    }
   }
 }

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "es2018",
     "module": "esnext",
     "moduleResolution": "node",
-    "lib": ["es2017"],
+    "lib": ["es2017", "dom"],
     "strict": true,
     "declaration": true,
     "declarationDir": "./dist/types",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -127,12 +127,15 @@ importers:
       '@ledgerhq/hw-app-exchange':
         specifier: ^0.22.2
         version: 0.22.2(rxjs@7.8.2)
-      '@ledgerhq/tracking-sdk':
-        specifier: ^1.5.0
-        version: 1.5.0
+      '@segment/analytics-next':
+        specifier: ^1.81.1
+        version: 1.81.1
       axios:
         specifier: ^1.3.4
         version: 1.3.4
+      zod:
+        specifier: ^3.22.4
+        version: 3.22.4
     devDependencies:
       '@ledgerhq/wallet-api-client':
         specifier: ^1.14.0


### PR DESCRIPTION
The tracking service never got finished as priorities changed, the exchange-sdk is the only one using it so to make maintainability easier I've moved all the logic into the library.

Also created a started kit for the `BackendService` and will create a different PR refactoring the current `api` logic to use this