### PR TITLE
feat: propagate swapEntryPoint and isEmbedded props

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@ledgerhq/wallet-api-client": "^1.14.0",
-    "@ledgerhq/wallet-api-exchange-module": "^0.27.0",
+    "@ledgerhq/wallet-api-exchange-module": "^0.32.0",
     "@ledgerhq/wallet-api-simulator": "^1.2.21",
     "@rollup/plugin-commonjs": "^25.0.4",
     "@rollup/plugin-node-resolve": "^15.2.1",

--- a/lib/src/sdk.test.ts
+++ b/lib/src/sdk.test.ts
@@ -180,6 +180,45 @@ describe("swap", () => {
     expect(swapId).toEqual("swap-id");
   });
 
+  it("forwards swapEntryPoint and isEmbedded to startSwap and completeSwap", async () => {
+
+    const currencies: Array<Partial<Currency>> = [
+      {
+        id: "currency-id-1",
+        decimals: 4,
+        family: "ethereum",
+      },
+    ];
+    mockCurrenciesList.mockResolvedValue(currencies as any);
+
+    const swapData = {
+      quoteId: "quoteId",
+      fromAccountId: "id-1",
+      toAccountId: "id-2",
+      fromAmount: new BigNumber("1.908"),
+      feeStrategy: "slow" as FeeStrategy,
+      rate: 1.2,
+      swapEntryPoint: "main_page",
+      isEmbedded: true,
+    };
+
+    const { transactionId } = await sdk.swap(swapData);
+
+    expect(transactionId).toEqual("TransactionId");
+    expect(mockStartSwapExchange).toHaveBeenCalledWith(
+      expect.objectContaining({
+        swapEntryPoint: "main_page",
+        isEmbedded: true,
+      }),
+    );
+    expect(mockCompleteSwap).toHaveBeenCalledWith(
+      expect.objectContaining({
+        swapEntryPoint: "main_page",
+        isEmbedded: true,
+      }),
+    );
+  });
+
   it("throws PayinExtraIdError error when no payinExtraId provided for stellar", async () => {
     const currencies: Array<Partial<Currency>> = [
       {

--- a/lib/src/sdk.test.ts
+++ b/lib/src/sdk.test.ts
@@ -180,7 +180,7 @@ describe("swap", () => {
     expect(swapId).toEqual("swap-id");
   });
 
-  it("forwards swapEntryPoint and isEmbeddedSwap to startSwap and completeSwap", async () => {
+  it("forwards swapEntryPoint and isEmbedded to startSwap and completeSwap", async () => {
 
     const currencies: Array<Partial<Currency>> = [
       {
@@ -199,7 +199,7 @@ describe("swap", () => {
       feeStrategy: "slow" as FeeStrategy,
       rate: 1.2,
       swapEntryPoint: "main_page",
-      isEmbeddedSwap: true,
+      isEmbedded: true,
     };
 
     const { transactionId } = await sdk.swap(swapData);
@@ -208,13 +208,13 @@ describe("swap", () => {
     expect(mockStartSwapExchange).toHaveBeenCalledWith(
       expect.objectContaining({
         swapEntryPoint: "main_page",
-        isEmbeddedSwap: true,
+        isEmbedded: true,
       }),
     );
     expect(mockCompleteSwap).toHaveBeenCalledWith(
       expect.objectContaining({
         swapEntryPoint: "main_page",
-        isEmbeddedSwap: true,
+        isEmbedded: true,
       }),
     );
   });

--- a/lib/src/sdk.test.ts
+++ b/lib/src/sdk.test.ts
@@ -180,7 +180,7 @@ describe("swap", () => {
     expect(swapId).toEqual("swap-id");
   });
 
-  it("forwards swapEntryPoint and isEmbedded to startSwap and completeSwap", async () => {
+  it("forwards swapEntryPoint and isEmbeddedSwap to startSwap and completeSwap", async () => {
 
     const currencies: Array<Partial<Currency>> = [
       {
@@ -199,7 +199,7 @@ describe("swap", () => {
       feeStrategy: "slow" as FeeStrategy,
       rate: 1.2,
       swapEntryPoint: "main_page",
-      isEmbedded: true,
+      isEmbeddedSwap: true,
     };
 
     const { transactionId } = await sdk.swap(swapData);
@@ -208,13 +208,13 @@ describe("swap", () => {
     expect(mockStartSwapExchange).toHaveBeenCalledWith(
       expect.objectContaining({
         swapEntryPoint: "main_page",
-        isEmbedded: true,
+        isEmbeddedSwap: true,
       }),
     );
     expect(mockCompleteSwap).toHaveBeenCalledWith(
       expect.objectContaining({
         swapEntryPoint: "main_page",
-        isEmbedded: true,
+        isEmbeddedSwap: true,
       }),
     );
   });

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -160,7 +160,8 @@ export class ExchangeSDK {
       toNewTokenId,
       swapAppVersion,
       getSwapPayload,
-      meta,
+      isEmbedded,
+      swapEntryPoint,
     } = info;
 
     const { account: fromAccount, currency: fromCurrency } =
@@ -182,7 +183,8 @@ export class ExchangeSDK {
           fromAccountId,
           toAccountId,
           tokenCurrency: toNewTokenId || "",
-          meta,
+          isEmbedded,
+          swapEntryPoint,
         })
         .catch((error: Error) => {
           const err = parseError({
@@ -258,7 +260,8 @@ export class ExchangeSDK {
         signature,
         feeStrategy,
         tokenCurrency: toNewTokenId,
-        meta,
+        isEmbedded,
+        swapEntryPoint,
       })
       .catch(async (error: Error) => {
         await this.cancelSwapOnError(

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -182,7 +182,7 @@ export class ExchangeSDK {
           fromAccountId,
           toAccountId,
           tokenCurrency: toNewTokenId || "",
-          ...meta,
+          meta,
         })
         .catch((error: Error) => {
           const err = parseError({
@@ -258,7 +258,7 @@ export class ExchangeSDK {
         signature,
         feeStrategy,
         tokenCurrency: toNewTokenId,
-        ...meta,
+        meta,
       })
       .catch(async (error: Error) => {
         await this.cancelSwapOnError(

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -160,8 +160,7 @@ export class ExchangeSDK {
       toNewTokenId,
       swapAppVersion,
       getSwapPayload,
-      swapEntryPoint,
-      isEmbedded,
+      meta,
     } = info;
 
     const { account: fromAccount, currency: fromCurrency } =
@@ -183,8 +182,7 @@ export class ExchangeSDK {
           fromAccountId,
           toAccountId,
           tokenCurrency: toNewTokenId || "",
-          swapEntryPoint,
-          isEmbedded,
+          ...meta,
         })
         .catch((error: Error) => {
           const err = parseError({
@@ -260,8 +258,7 @@ export class ExchangeSDK {
         signature,
         feeStrategy,
         tokenCurrency: toNewTokenId,
-        swapEntryPoint,
-        isEmbedded,
+        ...meta,
       })
       .catch(async (error: Error) => {
         await this.cancelSwapOnError(

--- a/lib/src/sdk.ts
+++ b/lib/src/sdk.ts
@@ -160,6 +160,8 @@ export class ExchangeSDK {
       toNewTokenId,
       swapAppVersion,
       getSwapPayload,
+      swapEntryPoint,
+      isEmbedded,
     } = info;
 
     const { account: fromAccount, currency: fromCurrency } =
@@ -181,6 +183,8 @@ export class ExchangeSDK {
           fromAccountId,
           toAccountId,
           tokenCurrency: toNewTokenId || "",
+          swapEntryPoint,
+          isEmbedded,
         })
         .catch((error: Error) => {
           const err = parseError({
@@ -256,6 +260,8 @@ export class ExchangeSDK {
         signature,
         feeStrategy,
         tokenCurrency: toNewTokenId,
+        swapEntryPoint,
+        isEmbedded,
       })
       .catch(async (error: Error) => {
         await this.cancelSwapOnError(

--- a/lib/src/sdk.types.ts
+++ b/lib/src/sdk.types.ts
@@ -35,6 +35,8 @@ export type SwapInfo = {
   rate: number;
   toNewTokenId?: string;
   swapAppVersion?: string;
+  swapEntryPoint?: string;
+  isEmbedded?: boolean;
   getSwapPayload?: GetSwapPayload;
 };
 

--- a/lib/src/sdk.types.ts
+++ b/lib/src/sdk.types.ts
@@ -23,7 +23,7 @@ export enum ProductType {
 }
 
 type SwapTrackingMeta = {
-  isEmbeddedSwap?: boolean;
+  isEmbedded?: boolean;
   swapEntryPoint?: string;
 };
 

--- a/lib/src/sdk.types.ts
+++ b/lib/src/sdk.types.ts
@@ -22,10 +22,7 @@ export enum ProductType {
   CARD = "CARD",
 }
 
-type SwapTrackingMeta = {
-  isEmbedded?: boolean;
-  swapEntryPoint?: string;
-};
+type SwapTrackingMeta = Record<string, unknown>;
 
 /**
  * Swap information required to request a user's swap transaction.

--- a/lib/src/sdk.types.ts
+++ b/lib/src/sdk.types.ts
@@ -22,6 +22,11 @@ export enum ProductType {
   CARD = "CARD",
 }
 
+type SwapTrackingMeta = {
+  isEmbeddedSwap?: boolean;
+  swapEntryPoint?: string;
+};
+
 /**
  * Swap information required to request a user's swap transaction.
  */
@@ -35,8 +40,7 @@ export type SwapInfo = {
   rate: number;
   toNewTokenId?: string;
   swapAppVersion?: string;
-  swapEntryPoint?: string;
-  isEmbedded?: boolean;
+  meta?: SwapTrackingMeta;
   getSwapPayload?: GetSwapPayload;
 };
 

--- a/lib/src/sdk.types.ts
+++ b/lib/src/sdk.types.ts
@@ -22,8 +22,6 @@ export enum ProductType {
   CARD = "CARD",
 }
 
-type SwapTrackingMeta = Record<string, unknown>;
-
 /**
  * Swap information required to request a user's swap transaction.
  */
@@ -37,7 +35,8 @@ export type SwapInfo = {
   rate: number;
   toNewTokenId?: string;
   swapAppVersion?: string;
-  meta?: SwapTrackingMeta;
+  isEmbedded?: boolean;
+  swapEntryPoint?: string;
   getSwapPayload?: GetSwapPayload;
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,8 +138,8 @@ importers:
         specifier: ^1.14.0
         version: 1.14.0(@ton/crypto@3.3.0)
       '@ledgerhq/wallet-api-exchange-module':
-        specifier: ^0.27.0
-        version: 0.27.0(@ton/crypto@3.3.0)
+        specifier: ^0.32.0
+        version: 0.32.0(@ton/crypto@3.3.0)
       '@ledgerhq/wallet-api-simulator':
         specifier: ^1.2.21
         version: 1.2.21(@ton/crypto@3.3.0)(react@19.1.0)
@@ -1156,8 +1156,8 @@ packages:
   '@ledgerhq/wallet-api-exchange-module@0.16.0-nightly.1':
     resolution: {integrity: sha512-O+hXCr32UIuX3z8xAPkRQsPsh+K2InBwDv1bzKHJs7AkVgPJ1QUCf/37V6Iv/4bmLiwB66OHX7MQ0ljH3u1fBQ==}
 
-  '@ledgerhq/wallet-api-exchange-module@0.27.0':
-    resolution: {integrity: sha512-k23pSXJ45TPL92ip4Ca8Q9n3TZ7ocbdfDezko9rk4eiSG7pGLyZu50rY/RKDFEFRDDQJkOD828bFdq/Sfl9D4g==}
+  '@ledgerhq/wallet-api-exchange-module@0.32.0':
+    resolution: {integrity: sha512-AwvPTNYLeAK/QQEU4udsV9dHegpMejf10jwBd086EFTLqm0p3ET2CONlJMxeijWioutSnc3BJSLOLQtjqbULsQ==}
 
   '@ledgerhq/wallet-api-server@1.13.4':
     resolution: {integrity: sha512-AzNVhRcC/aJbHiFl4SS/S/DaGOWiLXJrXFaf5vdtTOxPqwdc568qkduuW8gC0wnc7s/gflxI0XUXpuOlVesh6Q==}
@@ -6105,7 +6105,7 @@ snapshots:
       - '@ton/crypto'
       - encoding
 
-  '@ledgerhq/wallet-api-exchange-module@0.27.0(@ton/crypto@3.3.0)':
+  '@ledgerhq/wallet-api-exchange-module@0.32.0(@ton/crypto@3.3.0)':
     dependencies:
       '@ledgerhq/wallet-api-client': 1.14.0(@ton/crypto@3.3.0)
       '@ledgerhq/wallet-api-core': 1.30.0(@ton/crypto@3.3.0)


### PR DESCRIPTION
PR Forwards two new fields - swapEntryPoint and isEmbedded - from SwapInfo to both startSwap and completeSwap calls, enabling downstream consumers to track swap context and embedded mode. Adds a test to verify the pass-through.