### PR TITLE
feat(LIVE-33226): add aleo transaction strategy for swap

### DIFF
--- a/lib/src/wallet-api.test.ts
+++ b/lib/src/wallet-api.test.ts
@@ -1,5 +1,6 @@
 import BigNumber from "bignumber.js";
 import {
+  aleoTransaction,
   cosmosTransaction,
   defaultTransaction,
   elrondTransaction,
@@ -236,6 +237,43 @@ describe("hederaTransaction function", () => {
       amount: new BigNumber("10"),
       recipient: "ADDRESS",
       memo: "MEMO",
+    });
+  });
+});
+
+describe("aleoTransaction function", () => {
+  it('creates an AleoTransaction with mode: "transfer_public" and default fees', () => {
+    const transaction = aleoTransaction({
+      family: "aleo",
+      amount: new BigNumber("12"),
+      recipient: "ADDRESS",
+      customFeeConfig: {},
+    });
+
+    expect(transaction).toEqual({
+      family: "aleo",
+      amount: new BigNumber("12"),
+      recipient: "ADDRESS",
+      mode: "transfer_public",
+      fees: new BigNumber(0),
+    });
+  });
+
+  it("spreads customFeeConfig onto the transaction", () => {
+    const transaction = aleoTransaction({
+      family: "aleo",
+      amount: new BigNumber("3"),
+      recipient: "ADDRESS",
+      customFeeConfig: { fee: new BigNumber("0.5") },
+    });
+
+    expect(transaction).toEqual({
+      family: "aleo",
+      amount: new BigNumber("3"),
+      recipient: "ADDRESS",
+      fee: new BigNumber("0.5"),
+      mode: "transfer_public",
+      fees: new BigNumber(0),
     });
   });
 });

--- a/lib/src/wallet-api.ts
+++ b/lib/src/wallet-api.ts
@@ -1,4 +1,5 @@
 import {
+  AleoTransaction,
   CosmosTransaction,
   HederaTransaction,
   CryptoCurrency,
@@ -31,6 +32,7 @@ import { CustomModule } from "@ledgerhq/wallet-api-client";
 const transactionStrategy: {
   [K in Transaction["family"]]: TransactionStrategyFunction;
 } = {
+  aleo: aleoTransaction,
   algorand: defaultTransaction,
   aptos: defaultTransaction,
   bitcoin: bitcoinTransaction,
@@ -351,4 +353,18 @@ export function hederaTransaction({
     ...defaultTransaction({ family, amount, recipient, customFeeConfig }),
     memo: payinExtraId ?? undefined,
   } as HederaTransaction;
+}
+
+export function aleoTransaction({
+  family,
+  amount,
+  recipient,
+  customFeeConfig,
+}: TransactionWithCustomFee): AleoTransaction {
+  return {
+    ...defaultTransaction({ family, amount, recipient, customFeeConfig }),
+    mode: "transfer_public",
+    // Set a default value; completeExchange calls prepareTransaction, which sets fees again.
+    fees: new BigNumber(0),
+  } as AleoTransaction;
 }


### PR DESCRIPTION
Add the aleo family to the wallet-api transactionStrategy map so swaps can build an Aleo transfer_public transaction. Fees default to zero and are set again by prepareTransaction during completeExchange.

Requires @ledgerhq/wallet-api-client at a version whose Transaction union includes the aleo family; bump the dependency before merge.

LIVE-33226